### PR TITLE
feat(recording): only records json content type request/response.

### DIFF
--- a/otel/http/handler.go
+++ b/otel/http/handler.go
@@ -22,7 +22,7 @@ func (h *handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		r.Method,
 		trace.WithAttributes(
 			kv.String("http.method", r.Method),
-			kv.String("http.path", r.URL.Path),
+			kv.String("http.url", r.URL.String()),
 		),
 	)
 

--- a/otel/http/handler_test.go
+++ b/otel/http/handler_test.go
@@ -59,7 +59,7 @@ func TestRequestIsSuccessfullyTraced(t *testing.T) {
 
 	ih := NewHandler(h)
 
-	r, _ := http.NewRequest("GET", "http://traceable.ai/foo", strings.NewReader("test_request_body"))
+	r, _ := http.NewRequest("GET", "http://traceable.ai/foo?user_id=1", strings.NewReader("test_request_body"))
 	r.Header.Add("api_key", "xyz123abc")
 	w := httptest.NewRecorder()
 
@@ -76,8 +76,8 @@ func TestRequestIsSuccessfullyTraced(t *testing.T) {
 			assert.Equal(t, "202", kv.Value.AsString())
 		case "http.method":
 			assert.Equal(t, "GET", kv.Value.AsString())
-		case "http.path":
-			assert.Equal(t, "/foo", kv.Value.AsString())
+		case "http.url":
+			assert.Equal(t, "http://traceable.ai/foo?user_id=1", kv.Value.AsString())
 		case "http.request.header.request_id":
 			assert.Equal(t, "abc123xyz", kv.Value.AsString())
 		case "http.response.header.api_key":


### PR DESCRIPTION
This PR adds the logic to record request and response body for `application/json` content type.

Ping @davexroth @mohit-a21 