### PR TITLE
chore(examples): makes sure the examples still compile on CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
       - run: CGO_ENABLED=0 go test -coverprofile=coverage.txt -v ./...
       - codecov/upload:
           file: ./coverage.txt
+      - run: make build-examples
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+examples/output/*

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,9 @@ run-grpc-client-example:
 
 run-grpc-server-example:
 	go run examples/grpc/server/main.go
+
+build-examples:
+	go build -o ./examples/output/http_client examples/http/client/main.go
+	go build -o ./examples/output/http_server examples/http/server/main.go
+	go build -o ./examples/output/grpc_client examples/grpc/client/main.go
+	go build -o ./examples/output/grpc_server examples/grpc/server/main.go


### PR DESCRIPTION
This PR makes sure the examples are still compiling on CI. This is pretty useful when doping some refactors as even tests are the main source of truth it is very easy that examples get outdated.