### PR TITLE
chore(refactor): renames the interceptor wrappers for a more intuitive naming

### DIFF
--- a/examples/grpc/client/main.go
+++ b/examples/grpc/client/main.go
@@ -9,6 +9,10 @@ import (
 	"time"
 
 	pb "github.com/traceableai/goagent/examples/grpc/helloworld"
+	"github.com/traceableai/goagent/examples/internal"
+	traceablegrpc "github.com/traceableai/goagent/otel/grpc"
+	otelgrpc "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc"
+	"go.opentelemetry.io/otel/api/global"
 	"google.golang.org/grpc"
 )
 
@@ -18,11 +22,18 @@ const (
 )
 
 func main() {
+	internal.InitTracer("grpc-client")
+
 	// Set up a connection to the server.
 	conn, err := grpc.Dial(
 		address,
 		grpc.WithInsecure(),
 		grpc.WithBlock(),
+		grpc.WithUnaryInterceptor(
+			traceablegrpc.WrapUnaryClientInterceptor(
+				otelgrpc.UnaryClientInterceptor(global.TraceProvider().Tracer("ai.traceable")),
+			),
+		),
 	)
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)

--- a/examples/http/client/main.go
+++ b/examples/http/client/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/traceableai/goagent/examples/internal"
 	traceablehttp "github.com/traceableai/goagent/otel/http"
 	otelhttp "go.opentelemetry.io/contrib/instrumentation/net/http"
 )
@@ -19,6 +20,8 @@ type message struct {
 }
 
 func main() {
+	internal.InitTracer("http-client")
+
 	client := http.Client{
 		Transport: otelhttp.NewTransport(
 			traceablehttp.WrapTransport(http.DefaultTransport),

--- a/examples/http/server/main.go
+++ b/examples/http/server/main.go
@@ -10,11 +10,14 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/traceableai/goagent/examples/internal"
 	traceablehttp "github.com/traceableai/goagent/otel/http"
 	otelhttp "go.opentelemetry.io/contrib/instrumentation/net/http"
 )
 
 func main() {
+	internal.InitTracer("http-server")
+
 	r := mux.NewRouter()
 	r.Handle("/foo", otelhttp.NewHandler(
 		traceablehttp.WrapHandler(

--- a/examples/internal/tracer.go
+++ b/examples/internal/tracer.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+	"log"
+
+	"go.opentelemetry.io/otel/api/global"
+	"go.opentelemetry.io/otel/exporters/stdout"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/semconv"
+)
+
+// InitTracer initializes the tracer and register it globally
+func InitTracer(serviceName string) {
+	// Create stdout exporter to be able to retrieve
+	// the collected spans.
+	exporter, err := stdout.NewExporter(stdout.WithPrettyPrint())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// For the demonstration, use sdktrace.AlwaysSample sampler to sample all traces.
+	// In a production application, use sdktrace.ProbabilitySampler with a desired probability.
+	tp, err := sdktrace.NewProvider(
+		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
+		sdktrace.WithSyncer(exporter),
+		sdktrace.WithResource(resource.New(semconv.ServiceNameKey.String(serviceName))))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	global.SetTraceProvider(tp)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc v0.11.0
 	go.opentelemetry.io/contrib/instrumentation/net/http v0.11.0
 	go.opentelemetry.io/otel v0.11.0
+	go.opentelemetry.io/otel/exporters/stdout v0.11.0
 	go.opentelemetry.io/otel/sdk v0.11.0
 	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 // indirect
 	golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ go.opentelemetry.io/contrib/instrumentation/net/http v0.11.0 h1:ufewgDRmtrrdDpPg
 go.opentelemetry.io/contrib/instrumentation/net/http v0.11.0/go.mod h1:SBUSwgw/714EVSKHaAttjlJqbBv1YkUi+qdaN1oxMGE=
 go.opentelemetry.io/otel v0.11.0 h1:IN2tzQa9Gc4ZVKnTaMbPVcHjvzOdg5n9QfnmlqiET7E=
 go.opentelemetry.io/otel v0.11.0/go.mod h1:G8UCk+KooF2HLkgo8RHX9epABH/aRGYET7gQOqBVdB0=
+go.opentelemetry.io/otel/exporters/stdout v0.11.0 h1:5Hn/XKgq7aCJQWGacF093Ts1VpJuiJkwC75c1PqHTPE=
+go.opentelemetry.io/otel/exporters/stdout v0.11.0/go.mod h1:XP4gbV2Ikc7/ZyTGtwrA7/FzrhWJr3nfRU+LRvhxY24=
 go.opentelemetry.io/otel/sdk v0.11.0 h1:bkDMymVj6gIkPfgC5ci5atq0OYbfUHSn8NvsmyfyMq4=
 go.opentelemetry.io/otel/sdk v0.11.0/go.mod h1:XbZ6MrzIZ+d+qr7pH0FwHIbCnANMvXYgkq4afL/IUMQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/otel/grpc/client_test.go
+++ b/otel/grpc/client_test.go
@@ -9,6 +9,7 @@ import (
 	grpcinternal "github.com/traceableai/goagent/otel/grpc/internal"
 	"github.com/traceableai/goagent/otel/internal"
 	otel "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc"
+	"go.opentelemetry.io/otel/api/global"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -32,7 +33,11 @@ func TestClientRegisterPersonSuccess(t *testing.T) {
 		"bufnet",
 		grpc.WithContextDialer(dialer),
 		grpc.WithInsecure(),
-		grpc.WithUnaryInterceptor(NewUnaryClientInterceptor()),
+		grpc.WithUnaryInterceptor(
+			WrapUnaryClientInterceptor(
+				otel.UnaryClientInterceptor(global.TraceProvider().Tracer("ai.traceable")),
+			),
+		),
 	)
 	if err != nil {
 		t.Fatalf("failed to dial bufnet: %v", err)
@@ -96,7 +101,11 @@ func TestClientRegisterPersonFails(t *testing.T) {
 		"bufnet",
 		grpc.WithContextDialer(dialer),
 		grpc.WithInsecure(),
-		grpc.WithUnaryInterceptor(NewUnaryClientInterceptor()),
+		grpc.WithUnaryInterceptor(
+			WrapUnaryClientInterceptor(
+				otel.UnaryClientInterceptor(global.TraceProvider().Tracer("ai.traceable")),
+			),
+		),
 	)
 	if err != nil {
 		t.Fatalf("failed to dial bufnet: %v", err)
@@ -141,7 +150,11 @@ func BenchmarkClientRequestResponseBodyMarshaling(b *testing.B) {
 		"bufnet",
 		grpc.WithContextDialer(dialer),
 		grpc.WithInsecure(),
-		grpc.WithUnaryInterceptor(NewUnaryClientInterceptor()),
+		grpc.WithUnaryInterceptor(
+			WrapUnaryClientInterceptor(
+				otel.UnaryClientInterceptor(global.TraceProvider().Tracer("ai.traceable")),
+			),
+		),
 	)
 	if err != nil {
 		b.Fatalf("failed to dial bufnet: %v", err)

--- a/otel/grpc/server_test.go
+++ b/otel/grpc/server_test.go
@@ -9,6 +9,7 @@ import (
 	grpcinternal "github.com/traceableai/goagent/otel/grpc/internal"
 	"github.com/traceableai/goagent/otel/internal"
 	otel "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc"
+	"go.opentelemetry.io/otel/api/global"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -18,7 +19,11 @@ func TestServerRegisterPersonSuccess(t *testing.T) {
 	_, flusher := internal.InitTracer()
 
 	s := grpc.NewServer(
-		grpc.UnaryInterceptor(NewUnaryServerInterceptor()),
+		grpc.UnaryInterceptor(
+			WrapUnaryServerInterceptor(
+				otel.UnaryServerInterceptor(global.TraceProvider().Tracer("ai.traceable")),
+			),
+		),
 	)
 	defer s.Stop()
 
@@ -82,7 +87,11 @@ func TestServerRegisterPersonFails(t *testing.T) {
 	_, flusher := internal.InitTracer()
 
 	s := grpc.NewServer(
-		grpc.UnaryInterceptor(NewUnaryServerInterceptor()),
+		grpc.UnaryInterceptor(
+			WrapUnaryServerInterceptor(
+				otel.UnaryServerInterceptor(global.TraceProvider().Tracer("ai.traceable")),
+			),
+		),
 	)
 	defer s.Stop()
 
@@ -129,7 +138,11 @@ func BenchmarkServerRequestResponseBodyMarshaling(b *testing.B) {
 	internal.InitTracer()
 
 	s := grpc.NewServer(
-		grpc.UnaryInterceptor(NewUnaryServerInterceptor()),
+		grpc.UnaryInterceptor(
+			WrapUnaryServerInterceptor(
+				otel.UnaryServerInterceptor(global.TraceProvider().Tracer("ai.traceable")),
+			),
+		),
 	)
 	defer s.Stop()
 


### PR DESCRIPTION
This PR changes the interceptors name from the GRPC component to make it more explicit the wrapping.