### PR TITLE
feat(go-version): adds support for earlier Go versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@1
 
-executors:
-  golang_docker:
-    docker:
-      - image: cimg/go:1.14
 jobs:
-  build:
-    executor: golang_docker
+  build-and-test:
+    parameters:
+      go-version:
+        type: string
+    docker:
+      - image: cimg/go:<< parameters.go-version >>
     steps:
       - checkout
       - run: git config --global url."git@github.com:".insteadOf "https://github.com/"
@@ -24,6 +24,9 @@ jobs:
 
 workflows:
   version: 2
-  build:
+  build-and-test:
     jobs:
-      - build
+      - build-and-test:
+          matrix:
+            parameters:
+              go-version: ["1.13", "1.14", "1.15"]

--- a/instrumentation/net/http/contenttype.go
+++ b/instrumentation/net/http/contenttype.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 )
 
+// contentTypeAllowList is the list of allowed content types in lowercase
 var contentTypeAllowList = []string{
 	"application/json",
 	"application/x-www-form-urlencoded",
@@ -15,12 +16,8 @@ var contentTypeAllowList = []string{
 // not streamed.
 func shouldRecordBodyOfContentType(h http.Header) bool {
 	for _, contentType := range contentTypeAllowList {
-		// we look for cases like charset=UTF-8; application/json
-		for _, value := range h.Values("content-type") {
-			// type and subtype are case insensitive
-			if strings.ToLower(value) == strings.ToLower(contentType) {
-				return true
-			}
+		if strings.ToLower(h.Get("content-type")) == contentType {
+			return true
 		}
 	}
 	return false

--- a/instrumentation/net/http/contenttype_test.go
+++ b/instrumentation/net/http/contenttype_test.go
@@ -14,6 +14,7 @@ func TestKeyLookupSuccess(t *testing.T) {
 	}{
 		{"text/plain", false},
 		{"application/json", true},
+		{"Application/JSON", true},
 		{"application/x-www-form-urlencoded", true},
 	}
 

--- a/instrumentation/net/http/handler_test.go
+++ b/instrumentation/net/http/handler_test.go
@@ -83,8 +83,8 @@ func TestServerRecordsRequestAndResponseBodyAccordingly(t *testing.T) {
 	for name, tCase := range tCases {
 		t.Run(name, func(t *testing.T) {
 			h := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-				rw.Header().Add("Content-Type", "charset=UTF-8")
 				rw.Header().Add("Content-Type", tCase.responseContentType)
+				rw.Header().Add("Content-Type", "charset=UTF-8")
 				rw.Write([]byte(tCase.responseBody))
 			})
 

--- a/instrumentation/net/http/transport_test.go
+++ b/instrumentation/net/http/transport_test.go
@@ -132,8 +132,8 @@ func TestClientRecordsRequestAndResponseBodyAccordingly(t *testing.T) {
 	for name, tCase := range tCases {
 		t.Run(name, func(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-				rw.Header().Add("Content-Type", "charset=UTF-8")
 				rw.Header().Add("Content-Type", tCase.responseContentType)
+				rw.Header().Add("Content-Type", "charset=UTF-8")
 				rw.WriteHeader(202)
 				rw.Write([]byte(tCase.responseBody))
 			}))


### PR DESCRIPTION
by avoiding Header.Values and run tests for them on CI