### PR TITLE
chore(ux): changes StringVal and BoolVal into String and Bool to avoid confusion.

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -9,8 +9,8 @@ Agent config holds all the configuration settings for the Hypertrace Go Agent.
 cfg := config.Load()
 
 // overrides statically the service name
-cfg.ServiceName = config.StringVal("myservice")
-cfg.DataCapture.HTTPHeaders.Request = config.BoolVal(true)
+cfg.ServiceName = config.String("myservice")
+cfg.DataCapture.HTTPHeaders.Request = config.Bool(true)
 ```
 
 Values can also be overriden by the environment variables, e.g. `HT_DATA_CAPTURE_HTTP_HEADERS_RESPONSE=false`.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,7 +19,7 @@ func TestSourcesPrecedence(t *testing.T) {
 
 	// loads the config
 	cfg := Load()
-	cfg.DataCapture.RpcMetadata.Response = BoolVal(false)
+	cfg.DataCapture.RpcMetadata.Response = Bool(false)
 
 	// use defaults
 	assert.Equal(t, true, cfg.GetDataCapture().GetHttpBody().GetRequest().GetValue())

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -4,36 +4,38 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-// defaultConfig holds the default config for agent.
+// defaultConfig holds the default config values for agent.
 var defaultConfig = AgentConfig{
 	DataCapture: &DataCapture{
 		HttpHeaders: &Message{
-			Request:  BoolVal(true),
-			Response: BoolVal(true),
+			Request:  Bool(true),
+			Response: Bool(true),
 		},
 		HttpBody: &Message{
-			Request:  BoolVal(true),
-			Response: BoolVal(true),
+			Request:  Bool(true),
+			Response: Bool(true),
 		},
 		RpcMetadata: &Message{
-			Request:  BoolVal(true),
-			Response: BoolVal(true),
+			Request:  Bool(true),
+			Response: Bool(true),
 		},
 		RpcBody: &Message{
-			Request:  BoolVal(true),
-			Response: BoolVal(true),
+			Request:  Bool(true),
+			Response: Bool(true),
 		},
 	},
 	Reporting: &Reporting{
-		Address: StringVal("localhost"),
-		Secure:  BoolVal(false),
+		Address: String("localhost"),
+		Secure:  Bool(false),
 	},
 }
 
-func BoolVal(val bool) *wrapperspb.BoolValue {
+// Bool wraps the scalar value to be used in the AgentConfig object
+func Bool(val bool) *wrapperspb.BoolValue {
 	return &wrapperspb.BoolValue{Value: val}
 }
 
-func StringVal(val string) *wrapperspb.StringValue {
+// String wraps the scalar value to be used in the AgentConfig object
+func String(val string) *wrapperspb.StringValue {
 	return &wrapperspb.StringValue{Value: val}
 }

--- a/instrumentation/opencensus/init_test.go
+++ b/instrumentation/opencensus/init_test.go
@@ -4,9 +4,9 @@ import "github.com/hypertrace/goagent/config"
 
 func ExampleInit() {
 	cfg := config.Load()
-	cfg.ServiceName = config.StringVal("my_example_svc")
-	cfg.DataCapture.HttpHeaders.Request = config.BoolVal(true)
-	cfg.Reporting.Address = config.StringVal("api.traceable.ai")
+	cfg.ServiceName = config.String("my_example_svc")
+	cfg.DataCapture.HttpHeaders.Request = config.Bool(true)
+	cfg.Reporting.Address = config.String("api.traceable.ai")
 
 	shutdown := Init(cfg)
 	defer shutdown()

--- a/instrumentation/opentelemetry/init_test.go
+++ b/instrumentation/opentelemetry/init_test.go
@@ -4,9 +4,9 @@ import "github.com/hypertrace/goagent/config"
 
 func ExampleInit() {
 	cfg := config.Load()
-	cfg.ServiceName = config.StringVal("my_example_svc")
-	cfg.DataCapture.HttpHeaders.Request = config.BoolVal(true)
-	cfg.Reporting.Address = config.StringVal("api.traceable.ai")
+	cfg.ServiceName = config.String("my_example_svc")
+	cfg.DataCapture.HttpHeaders.Request = config.Bool(true)
+	cfg.Reporting.Address = config.String("api.traceable.ai")
 
 	shutdown := Init(cfg)
 	defer shutdown()

--- a/instrumentation/opentelemetry/net/hyperhttp/examples/tracer.go
+++ b/instrumentation/opentelemetry/net/hyperhttp/examples/tracer.go
@@ -9,10 +9,10 @@ import (
 func InitTracer(serviceName string) func() {
 	cfg := config.Load()
 
-	cfg.ServiceName = config.StringVal(serviceName)
+	cfg.ServiceName = config.String(serviceName)
 
-	cfg.Reporting.Address = config.StringVal("localhost")
-	cfg.Reporting.Secure = config.BoolVal(false)
+	cfg.Reporting.Address = config.String("localhost")
+	cfg.Reporting.Secure = config.Bool(false)
 
 	return opentelemetry.Init(cfg)
 }

--- a/sdk/internal/config/config_test.go
+++ b/sdk/internal/config/config_test.go
@@ -8,6 +8,6 @@ import (
 
 func TestConfig(t *testing.T) {
 	InitConfig(&config.AgentConfig{
-		ServiceName: config.StringVal("my_service"),
+		ServiceName: config.String("my_service"),
 	})
 }

--- a/sdk/net/http/handler_test.go
+++ b/sdk/net/http/handler_test.go
@@ -31,12 +31,12 @@ func TestMain(m *testing.M) {
 	sdkconfig.InitConfig(&config.AgentConfig{
 		DataCapture: &config.DataCapture{
 			HttpHeaders: &config.Message{
-				Request:  config.BoolVal(true),
-				Response: config.BoolVal(true),
+				Request:  config.Bool(true),
+				Response: config.Bool(true),
 			},
 			HttpBody: &config.Message{
-				Request:  config.BoolVal(true),
-				Response: config.BoolVal(true),
+				Request:  config.Bool(true),
+				Response: config.Bool(true),
 			},
 		},
 	})
@@ -53,8 +53,8 @@ func TestServerRequestIsSuccessfullyTraced(t *testing.T) {
 	wh, _ := WrapHandler(h, mock.SpanFromContext).(*handler)
 	wh.dataCaptureConfig = &config.DataCapture{
 		HttpHeaders: &config.Message{
-			Request:  config.BoolVal(true),
-			Response: config.BoolVal(true),
+			Request:  config.Bool(true),
+			Response: config.Bool(true),
 		},
 	}
 	ih := &mockHandler{baseHandler: wh}
@@ -134,8 +134,8 @@ func TestServerRecordsRequestAndResponseBodyAccordingly(t *testing.T) {
 			wh, _ := WrapHandler(h, mock.SpanFromContext).(*handler)
 			wh.dataCaptureConfig = &config.DataCapture{
 				HttpBody: &config.Message{
-					Request:  config.BoolVal(tCase.captureHTTPBodyConfig),
-					Response: config.BoolVal(tCase.captureHTTPBodyConfig),
+					Request:  config.Bool(tCase.captureHTTPBodyConfig),
+					Response: config.Bool(tCase.captureHTTPBodyConfig),
 				},
 			}
 			ih := &mockHandler{baseHandler: wh}


### PR DESCRIPTION
Functions `config.StringVal` and `config.BoolVal` allow user to easily return values to be used in the agent config, however and more so because this is a config, they could give the sense that we are retrieving the value for a config with a given key. Hence this change removes the suffix 'Val' to avoid such confusion. Thanks to @marc-gr for the hint.