### PR TITLE
feat(sql): adds support for span kind.

### DIFF
--- a/instrumentation/opencensus/database/hypersql/sql_test.go
+++ b/instrumentation/opencensus/database/hypersql/sql_test.go
@@ -52,7 +52,8 @@ func TestQuerySuccess(t *testing.T) {
 	assert.Equal(t, 1, len(spans))
 
 	span := spans[0]
-	assert.Equal(t, "db:query", spans[0].Name)
+	assert.Equal(t, "db:query", span.Name)
+	assert.Equal(t, trace.SpanKindClient, span.SpanKind)
 
 	assert.Equal(t, "SELECT 1 WHERE 1 = ?", span.Attributes["db.statement"].(string))
 	assert.Equal(t, "sqlite", span.Attributes["db.system"].(string))
@@ -83,6 +84,7 @@ func TestExecSuccess(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal(t, "db:exec", span.Name)
+	assert.Equal(t, trace.SpanKindClient, span.SpanKind)
 
 	_, ok := span.Attributes["error"]
 	assert.False(t, ok)
@@ -129,6 +131,7 @@ func TestTxWithCommitSuccess(t *testing.T) {
 	assert.Equal(t, "db:commit", spans[4].Name)
 
 	for i := 0; i < 5; i++ {
+		assert.Equal(t, trace.SpanKindClient, spans[i].SpanKind)
 		_, ok := spans[i].Attributes["error"]
 		assert.False(t, ok)
 	}
@@ -174,6 +177,7 @@ func TestTxWithRollbackSuccess(t *testing.T) {
 	assert.Equal(t, "db:rollback", spans[4].Name)
 
 	for i := 0; i < 5; i++ {
+		assert.Equal(t, trace.SpanKindClient, spans[i].SpanKind)
 		_, ok := spans[i].Attributes["error"]
 		assert.False(t, ok)
 	}

--- a/instrumentation/opencensus/span.go
+++ b/instrumentation/opencensus/span.go
@@ -40,14 +40,14 @@ func SpanFromContext(ctx context.Context) sdk.Span {
 
 func StartSpan(ctx context.Context, name string, options *sdk.SpanOptions) (context.Context, sdk.Span, func()) {
 	startOpts := []trace.StartOption{
-		trace.WithSpanKind(toOCSpanKind(options.Kind)),
+		trace.WithSpanKind(mapSpanKind(options.Kind)),
 	}
 
 	ctx, span := trace.StartSpan(ctx, name, startOpts...)
 	return ctx, &Span{span}, span.End
 }
 
-func toOCSpanKind(kind sdk.SpanKind) int {
+func mapSpanKind(kind sdk.SpanKind) int {
 	switch kind {
 	case sdk.Client:
 		return trace.SpanKindClient

--- a/instrumentation/opencensus/span.go
+++ b/instrumentation/opencensus/span.go
@@ -38,7 +38,22 @@ func SpanFromContext(ctx context.Context) sdk.Span {
 	return &Span{trace.FromContext(ctx)}
 }
 
-func StartSpan(ctx context.Context, name string) (context.Context, sdk.Span, func()) {
-	ctx, span := trace.StartSpan(ctx, name)
+func StartSpan(ctx context.Context, name string, options *sdk.SpanOptions) (context.Context, sdk.Span, func()) {
+	startOpts := []trace.StartOption{
+		trace.WithSpanKind(toOCSpanKind(options.Kind)),
+	}
+
+	ctx, span := trace.StartSpan(ctx, name, startOpts...)
 	return ctx, &Span{span}, span.End
+}
+
+func toOCSpanKind(kind sdk.SpanKind) int {
+	switch kind {
+	case sdk.Client:
+		return trace.SpanKindClient
+	case sdk.Server:
+		return trace.SpanKindServer
+	default:
+		return trace.SpanKindUnspecified
+	}
 }

--- a/instrumentation/opencensus/span_test.go
+++ b/instrumentation/opencensus/span_test.go
@@ -1,4 +1,4 @@
-package opencensus_test
+package opencensus
 
 import (
 	"context"
@@ -6,16 +6,21 @@ import (
 
 	"go.opencensus.io/trace"
 
-	"github.com/hypertrace/goagent/instrumentation/opencensus"
+	"github.com/hypertrace/goagent/sdk"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestIsNoop(t *testing.T) {
 	_, unsampledSpan := trace.StartSpan(context.Background(), "test", trace.WithSampler(trace.NeverSample()))
-	span := &opencensus.Span{unsampledSpan}
+	span := &Span{unsampledSpan}
 	assert.True(t, span.IsNoop())
 
 	_, sampledSpan := trace.StartSpan(context.Background(), "test", trace.WithSampler(trace.AlwaysSample()))
-	span = &opencensus.Span{sampledSpan}
+	span = &Span{sampledSpan}
 	assert.False(t, span.IsNoop())
+}
+
+func TestMapSpanKind(t *testing.T) {
+	assert.Equal(t, mapSpanKind(sdk.Client), trace.SpanKindClient)
+	assert.Equal(t, mapSpanKind(sdk.Server), trace.SpanKindServer)
 }

--- a/instrumentation/opentelemetry/database/hypersql/sql_test.go
+++ b/instrumentation/opentelemetry/database/hypersql/sql_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hypertrace/goagent/instrumentation/opentelemetry/internal"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
+	apitrace "go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/sdk/export/trace"
 )
 
@@ -52,7 +53,8 @@ func TestQuerySuccess(t *testing.T) {
 	assert.Equal(t, 1, len(spans))
 
 	span := spans[0]
-	assert.Equal(t, "db:query", spans[0].Name)
+	assert.Equal(t, "db:query", span.Name)
+	assert.Equal(t, apitrace.SpanKindClient, span.SpanKind)
 
 	attrs := internal.LookupAttributes(span.Attributes)
 	assert.Equal(t, "SELECT 1 WHERE 1 = ?", attrs.Get("db.statement").AsString())
@@ -83,6 +85,7 @@ func TestExecSuccess(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal(t, "db:exec", span.Name)
+	assert.Equal(t, apitrace.SpanKindClient, span.SpanKind)
 
 	attrs := internal.LookupAttributes(span.Attributes)
 	assert.False(t, attrs.Has("error"))
@@ -129,6 +132,7 @@ func TestTxWithCommitSuccess(t *testing.T) {
 	assert.Equal(t, "db:commit", spans[4].Name)
 
 	for i := 0; i < 5; i++ {
+		assert.Equal(t, apitrace.SpanKindClient, spans[i].SpanKind)
 		attrs := internal.LookupAttributes(spans[i].Attributes)
 		assert.False(t, attrs.Has("error"))
 	}
@@ -174,6 +178,7 @@ func TestTxWithRollbackSuccess(t *testing.T) {
 	assert.Equal(t, "db:rollback", spans[4].Name)
 
 	for i := 0; i < 5; i++ {
+		assert.Equal(t, apitrace.SpanKindClient, spans[i].SpanKind)
 		attrs := internal.LookupAttributes(spans[i].Attributes)
 		assert.False(t, attrs.Has("error"))
 	}

--- a/instrumentation/opentelemetry/span.go
+++ b/instrumentation/opentelemetry/span.go
@@ -29,14 +29,14 @@ func SpanFromContext(ctx context.Context) sdk.Span {
 
 func StartSpan(ctx context.Context, name string, options *sdk.SpanOptions) (context.Context, sdk.Span, func()) {
 	startOpts := []trace.StartOption{
-		trace.WithSpanKind(toOTelSpanKind(options.Kind)),
+		trace.WithSpanKind(mapSpanKind(options.Kind)),
 	}
 
 	ctx, span := global.Tracer(TracerDomain).Start(ctx, name, startOpts...)
 	return ctx, &Span{span}, func() { span.End() }
 }
 
-func toOTelSpanKind(kind sdk.SpanKind) trace.SpanKind {
+func mapSpanKind(kind sdk.SpanKind) trace.SpanKind {
 	switch kind {
 	case sdk.Client:
 		return trace.SpanKindClient

--- a/instrumentation/opentelemetry/span.go
+++ b/instrumentation/opentelemetry/span.go
@@ -27,7 +27,26 @@ func SpanFromContext(ctx context.Context) sdk.Span {
 	return &Span{trace.SpanFromContext(ctx)}
 }
 
-func StartSpan(ctx context.Context, name string) (context.Context, sdk.Span, func()) {
-	ctx, span := global.Tracer(TracerDomain).Start(ctx, name)
+func StartSpan(ctx context.Context, name string, options *sdk.SpanOptions) (context.Context, sdk.Span, func()) {
+	startOpts := []trace.StartOption{
+		trace.WithSpanKind(toOTelSpanKind(options.Kind)),
+	}
+
+	ctx, span := global.Tracer(TracerDomain).Start(ctx, name, startOpts...)
 	return ctx, &Span{span}, func() { span.End() }
+}
+
+func toOTelSpanKind(kind sdk.SpanKind) trace.SpanKind {
+	switch kind {
+	case sdk.Client:
+		return trace.SpanKindClient
+	case sdk.Server:
+		return trace.SpanKindServer
+	case sdk.Producer:
+		return trace.SpanKindProducer
+	case sdk.Consumer:
+		return trace.SpanKindConsumer
+	default:
+		return trace.SpanKindUnspecified
+	}
 }

--- a/instrumentation/opentelemetry/span_test.go
+++ b/instrumentation/opentelemetry/span_test.go
@@ -1,22 +1,29 @@
-package opentelemetry_test
+package opentelemetry
 
 import (
 	"context"
 	"testing"
 
 	"github.com/hypertrace/goagent/config"
-	"github.com/hypertrace/goagent/instrumentation/opentelemetry"
+	"github.com/hypertrace/goagent/sdk"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/trace"
 )
 
 func TestIsNoop(t *testing.T) {
-	span := &opentelemetry.Span{trace.NoopSpan{}}
+	span := &Span{trace.NoopSpan{}}
 	assert.True(t, span.IsNoop())
 
-	opentelemetry.Init(config.Load())
-	_, delegateSpan := global.Tracer(opentelemetry.TracerDomain).Start(context.Background(), "test_span")
-	span = &opentelemetry.Span{delegateSpan}
+	Init(config.Load())
+	_, delegateSpan := global.Tracer(TracerDomain).Start(context.Background(), "test_span")
+	span = &Span{delegateSpan}
 	assert.False(t, span.IsNoop())
+}
+
+func TestMapSpanKind(t *testing.T) {
+	assert.Equal(t, mapSpanKind(sdk.Client), trace.SpanKindClient)
+	assert.Equal(t, mapSpanKind(sdk.Server), trace.SpanKindServer)
+	assert.Equal(t, mapSpanKind(sdk.Producer), trace.SpanKindProducer)
+	assert.Equal(t, mapSpanKind(sdk.Consumer), trace.SpanKindConsumer)
 }

--- a/sdk/database/hypersql/sql.go
+++ b/sdk/database/hypersql/sql.go
@@ -22,7 +22,7 @@ type interceptor struct {
 }
 
 func (in *interceptor) StmtQueryContext(ctx context.Context, conn driver.StmtQueryContext, query string, args []driver.NamedValue) (driver.Rows, error) {
-	ctx, span, end := in.startSpan(ctx, "db:query")
+	ctx, span, end := in.startSpan(ctx, "db:query", &sdk.SpanOptions{Kind: sdk.Client})
 	defer end()
 
 	for key, value := range in.defaultAttributes {
@@ -39,7 +39,7 @@ func (in *interceptor) StmtQueryContext(ctx context.Context, conn driver.StmtQue
 }
 
 func (in *interceptor) StmtExecContext(ctx context.Context, conn driver.StmtExecContext, query string, args []driver.NamedValue) (driver.Result, error) {
-	ctx, span, end := in.startSpan(ctx, "db:exec")
+	ctx, span, end := in.startSpan(ctx, "db:exec", &sdk.SpanOptions{Kind: sdk.Client})
 	defer end()
 
 	for key, value := range in.defaultAttributes {
@@ -56,7 +56,7 @@ func (in *interceptor) StmtExecContext(ctx context.Context, conn driver.StmtExec
 }
 
 func (in *interceptor) ConnQueryContext(ctx context.Context, conn driver.QueryerContext, query string, args []driver.NamedValue) (driver.Rows, error) {
-	ctx, span, end := in.startSpan(ctx, "db:query")
+	ctx, span, end := in.startSpan(ctx, "db:query", &sdk.SpanOptions{Kind: sdk.Client})
 	defer end()
 
 	for key, value := range in.defaultAttributes {
@@ -73,7 +73,7 @@ func (in *interceptor) ConnQueryContext(ctx context.Context, conn driver.Queryer
 }
 
 func (in *interceptor) ConnExecContext(ctx context.Context, conn driver.ExecerContext, query string, args []driver.NamedValue) (driver.Result, error) {
-	ctx, span, end := in.startSpan(ctx, "db:exec")
+	ctx, span, end := in.startSpan(ctx, "db:exec", &sdk.SpanOptions{Kind: sdk.Client})
 	defer end()
 
 	for key, value := range in.defaultAttributes {
@@ -90,7 +90,7 @@ func (in *interceptor) ConnExecContext(ctx context.Context, conn driver.ExecerCo
 }
 
 func (in *interceptor) ConnBeginTx(ctx context.Context, conn driver.ConnBeginTx, txOpts driver.TxOptions) (driver.Tx, error) {
-	ctx, span, end := in.startSpan(ctx, "db:begin_transaction")
+	ctx, span, end := in.startSpan(ctx, "db:begin_transaction", &sdk.SpanOptions{Kind: sdk.Client})
 	defer end()
 
 	for key, value := range in.defaultAttributes {
@@ -106,7 +106,7 @@ func (in *interceptor) ConnBeginTx(ctx context.Context, conn driver.ConnBeginTx,
 }
 
 func (in *interceptor) ConnPrepareContext(ctx context.Context, conn driver.ConnPrepareContext, query string) (driver.Stmt, error) {
-	ctx, span, end := in.startSpan(ctx, "db:prepare")
+	ctx, span, end := in.startSpan(ctx, "db:prepare", &sdk.SpanOptions{Kind: sdk.Client})
 	defer end()
 
 	for key, value := range in.defaultAttributes {
@@ -122,7 +122,7 @@ func (in *interceptor) ConnPrepareContext(ctx context.Context, conn driver.ConnP
 }
 
 func (in *interceptor) TxCommit(ctx context.Context, tx driver.Tx) error {
-	ctx, span, end := in.startSpan(ctx, "db:commit")
+	ctx, span, end := in.startSpan(ctx, "db:commit", &sdk.SpanOptions{Kind: sdk.Client})
 	defer end()
 
 	for key, value := range in.defaultAttributes {
@@ -138,7 +138,7 @@ func (in *interceptor) TxCommit(ctx context.Context, tx driver.Tx) error {
 }
 
 func (in *interceptor) TxRollback(ctx context.Context, tx driver.Tx) error {
-	ctx, span, end := in.startSpan(ctx, "db:rollback")
+	ctx, span, end := in.startSpan(ctx, "db:rollback", &sdk.SpanOptions{Kind: sdk.Client})
 	defer end()
 
 	for key, value := range in.defaultAttributes {

--- a/sdk/database/hypersql/sql_test.go
+++ b/sdk/database/hypersql/sql_test.go
@@ -17,7 +17,7 @@ type spansBuffer struct {
 	spans []*mock.Span
 }
 
-func (sb *spansBuffer) StartSpan(ctx context.Context, name string) (context.Context, sdk.Span, func()) {
+func (sb *spansBuffer) StartSpan(ctx context.Context, name string, _ *sdk.SpanOptions) (context.Context, sdk.Span, func()) {
 	s := mock.NewSpan()
 	s.Name = name
 	sb.spans = append(sb.spans, s)

--- a/sdk/database/hypersql/sql_test.go
+++ b/sdk/database/hypersql/sql_test.go
@@ -17,9 +17,10 @@ type spansBuffer struct {
 	spans []*mock.Span
 }
 
-func (sb *spansBuffer) StartSpan(ctx context.Context, name string, _ *sdk.SpanOptions) (context.Context, sdk.Span, func()) {
+func (sb *spansBuffer) StartSpan(ctx context.Context, name string, opts *sdk.SpanOptions) (context.Context, sdk.Span, func()) {
 	s := mock.NewSpan()
 	s.Name = name
+	s.Options = *opts
 	sb.spans = append(sb.spans, s)
 	return mock.ContextWithSpan(ctx, s), s, func() {}
 }
@@ -64,6 +65,7 @@ func TestQuerySuccess(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal(t, "db:query", span.Name)
+	assert.Equal(t, sdk.Client, span.Options.Kind)
 
 	assert.Equal(t, "SELECT 1 WHERE 1 = ?", span.ReadAttribute("db.statement").(string))
 	assert.Equal(t, "sqlite", span.ReadAttribute("db.system").(string))
@@ -93,6 +95,7 @@ func TestExecSuccess(t *testing.T) {
 	assert.Equal(t, 1, len(spans))
 
 	span := spans[0]
+	assert.Equal(t, sdk.Client, span.Options.Kind)
 	assert.Equal(t, "db:exec", span.Name)
 	assert.Nil(t, span.ReadAttribute("error"))
 }
@@ -138,6 +141,7 @@ func TestTxWithCommitSuccess(t *testing.T) {
 	assert.Equal(t, "db:commit", spans[4].Name)
 
 	for i := 0; i < 5; i++ {
+		assert.Equal(t, sdk.Client, spans[i].Options.Kind)
 		assert.Nil(t, spans[i].ReadAttribute("error"))
 	}
 
@@ -182,6 +186,7 @@ func TestTxWithRollbackSuccess(t *testing.T) {
 	assert.Equal(t, "db:rollback", spans[4].Name)
 
 	for i := 0; i < 5; i++ {
+		assert.Equal(t, sdk.Client, spans[i].Options.Kind)
 		assert.Nil(t, spans[i].ReadAttribute("error"))
 	}
 

--- a/sdk/internal/mock/span.go
+++ b/sdk/internal/mock/span.go
@@ -12,6 +12,7 @@ var _ sdk.Span = &Span{}
 type Span struct {
 	Name       string
 	Attributes map[string]interface{}
+	Options    sdk.SpanOptions
 	err        error
 	Noop       bool
 	mux        *sync.Mutex
@@ -62,8 +63,8 @@ func SpanFromContext(ctx context.Context) sdk.Span {
 	return ctx.Value(spanKey("span")).(*Span)
 }
 
-func StartSpan(ctx context.Context, name string) (context.Context, sdk.Span, func()) {
-	s := &Span{Name: name}
+func StartSpan(ctx context.Context, name string, opts *sdk.SpanOptions) (context.Context, sdk.Span, func()) {
+	s := &Span{Name: name, Options: *opts}
 	return ContextWithSpan(ctx, s), s, func() {}
 }
 

--- a/sdk/internal/mock/span.go
+++ b/sdk/internal/mock/span.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/hypertrace/goagent/sdk"
@@ -64,6 +65,7 @@ func SpanFromContext(ctx context.Context) sdk.Span {
 }
 
 func StartSpan(ctx context.Context, name string, opts *sdk.SpanOptions) (context.Context, sdk.Span, func()) {
+	fmt.Println(opts)
 	s := &Span{Name: name, Options: *opts}
 	return ContextWithSpan(ctx, s), s, func() {}
 }

--- a/sdk/span.go
+++ b/sdk/span.go
@@ -19,5 +19,22 @@ type Span interface {
 // SpanFromContext retrieves the existing span from a context
 type SpanFromContext func(ctx context.Context) Span
 
+// SpanKind represents the span kind, either Client, Server,
+// Producer, Consumer or undertermine
+type SpanKind string
+
+const (
+	Undetermined SpanKind = ""
+	Client       SpanKind = "CLIENT"
+	Server       SpanKind = "SERVER"
+	Producer     SpanKind = "PRODUCER"
+	Consumer     SpanKind = "CONSUMER"
+)
+
+// SpanOptions describes the options for starting a span
+type SpanOptions struct {
+	Kind SpanKind
+}
+
 // StartSpan creates a span and injects into a context, returning a span ender function
-type StartSpan func(ctx context.Context, name string) (context.Context, Span, func())
+type StartSpan func(ctx context.Context, name string, opts *SpanOptions) (context.Context, Span, func())


### PR DESCRIPTION
Somehow we weren't supporting span kind for SQL instrumentation (important for ingress/egress), hence we added support inside SDK here.

The reason why we do object config instead of functional arguments is because I think it is less *gopherish* but easier to understand, discover and read.