### PR TITLE
chore(ci): fixes codecov config.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,0 @@
-codecov:
-  require_ci_to_pass: false
-
-  ignore:
-    - "config"
-    - "examples"
-    - "tests"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+require_ci_to_pass: false
+
+ignore:
+  - "config"
+  - "examples"
+  - "tests"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,3 @@
-require_ci_to_pass: false
-
 ignore:
   - "config"
   - "examples"


### PR DESCRIPTION
codecov used an old config so we are fixing it to make it possible to ignore paths.