### PR TITLE
fix(http-server): fixes mutation of the request body as when nil we mutated into an empty one.

### DIFF
--- a/sdk/net/http/handler.go
+++ b/sdk/net/http/handler.go
@@ -48,11 +48,13 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	span.SetAttribute("http.url", r.URL.String())
 
 	// Sets an attribute per each request header.
-	if h.dataCaptureConfig.GetHttpHeaders().Request.Value {
+	if h.dataCaptureConfig.HttpHeaders.Request.Value {
 		setAttributesFromHeaders("request", r.Header, span)
 	}
 
-	if h.dataCaptureConfig.HttpBody.Request.Value && shouldRecordBodyOfContentType(r.Header) {
+	// nil check for body is important as this block turns the body into another
+	// object that isn't nil and that will leverage the "Observer effect".
+	if r.Body != nil && h.dataCaptureConfig.HttpBody.Request.Value && shouldRecordBodyOfContentType(r.Header) {
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			return

--- a/sdk/net/http/handler_test.go
+++ b/sdk/net/http/handler_test.go
@@ -26,6 +26,34 @@ func (h *mockHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	h.baseHandler.ServeHTTP(rw, r.WithContext(ctx))
 }
 
+func TestServerRequestWithNilBodyIsntChanged(t *testing.T) {
+	h := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		assert.Nil(t, r.Body)
+	})
+
+	wh, _ := WrapHandler(h, mock.SpanFromContext).(*handler)
+	wh.dataCaptureConfig = &config.DataCapture{
+		HttpHeaders: &config.Message{
+			Request:  config.Bool(false),
+			Response: config.Bool(false),
+		},
+		HttpBody: &config.Message{
+			Request:  config.Bool(true),
+			Response: config.Bool(false),
+		},
+	}
+
+	ih := &mockHandler{baseHandler: wh}
+
+	r, _ := http.NewRequest("GET", "http://traceable.ai/foo?user_id=1", nil)
+	r.Header.Add("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	ih.ServeHTTP(w, r)
+
+	assert.Equal(t, 1, len(ih.spans))
+}
+
 func TestServerRequestIsSuccessfullyTraced(t *testing.T) {
 	h := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Add("request_id", "abc123xyz")


### PR DESCRIPTION
This PR fixes an issue with http-server instrumentation as when the body was nil we were mutating it into an empty body and that was breaking a specific condition in a user's code.