### PR TITLE
fix(opentelemetry|hypertrace): fixes opentelemetry propagation support.

### DIFF
--- a/instrumentation/hypertrace/github.com/gorilla/hypermux/examples/server/main.go
+++ b/instrumentation/hypertrace/github.com/gorilla/hypermux/examples/server/main.go
@@ -18,14 +18,14 @@ import (
 
 func main() {
 	cfg := config.Load()
-	cfg.ServiceName = config.String("http-server")
+	cfg.ServiceName = config.String("http-mux-server")
 
 	flusher := hypertrace.Init(cfg)
 	defer flusher()
 
 	r := mux.NewRouter()
 	r.Use(hypermux.NewMiddleware()) // here we use the mux middleware
-	r.Handle(http.HandlerFunc(fooHandler))
+	r.HandleFunc("/foo", http.HandlerFunc(fooHandler))
 	log.Fatal(http.ListenAndServe(":8081", r))
 }
 

--- a/instrumentation/hypertrace/init.go
+++ b/instrumentation/hypertrace/init.go
@@ -11,6 +11,7 @@ import (
 	sdkconfig "github.com/hypertrace/goagent/sdk/config"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/trace/zipkin"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/semconv"
@@ -54,6 +55,10 @@ func Init(cfg *config.AgentConfig) func() {
 	}
 	otel.SetTracerProvider(tp)
 
+	// TODO: support configurable propagation
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	// TODO: use batcher instead of this hack:
 	return func() {
 		// This is a sad temporary solution for the lack of flusher in the batcher interface.
 		// What we do here is that we wait for `batchTimeout` seconds as that is the time configured

--- a/instrumentation/opentelemetry/init.go
+++ b/instrumentation/opentelemetry/init.go
@@ -12,6 +12,7 @@ import (
 	sdkconfig "github.com/hypertrace/goagent/sdk/config"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/trace/zipkin"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/semconv"
@@ -52,6 +53,10 @@ func Init(cfg *config.AgentConfig) func() {
 	)
 	otel.SetTracerProvider(tp)
 
+	// TODO: support configurable propagation
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	// TODO: use batcher instead of this hack:
 	return func() {
 		// This is a sad temporary solution for the lack of flusher in the batcher interface.
 		// What we do here is that we wait for `batchTimeout` seconds as that is the time configured


### PR DESCRIPTION
TraceContext propagation support isn't enabled anymore in opentelemetry libraries by default. In this repo we reenable them.

Related to https://github.com/hypertrace/goagent/pull/67