### PR TITLE
Fix content type lookup

### DIFF
--- a/instrumentation/opentelemetry/github.com/gorilla/hypermux/mux_test.go
+++ b/instrumentation/opentelemetry/github.com/gorilla/hypermux/mux_test.go
@@ -75,7 +75,6 @@ func TestSpanRecordedCorrectly(t *testing.T) {
 	assert.Equal(t, "/things/{thing_id}", span.Name)
 	assert.Equal(t, span.SpanKind, trace.SpanKindServer)
 
-	fmt.Println(span.Attributes)
 	attrs := internal.LookupAttributes(span.Attributes)
 	assert.Equal(t, "POST", attrs.Get("http.method").AsString())
 	assert.Equal(t, "abc123xyz", attrs.Get("http.request.header.Api_key").AsString())

--- a/sdk/net/http/contenttype.go
+++ b/sdk/net/http/contenttype.go
@@ -1,24 +1,7 @@
 package http
 
-import (
-	"net/http"
-	"strings"
-)
-
 // contentTypeAllowList is the list of allowed content types in lowercase
 var contentTypeAllowList = []string{
 	"application/json",
 	"application/x-www-form-urlencoded",
-}
-
-// shouldRecordBodyOfContentType checks if the body is meant
-// to be recorded based on the content-type and the fact that body is
-// not streamed.
-func shouldRecordBodyOfContentType(h http.Header) bool {
-	for _, contentType := range contentTypeAllowList {
-		if strings.ToLower(h.Get("content-type")) == contentType {
-			return true
-		}
-	}
-	return false
 }

--- a/sdk/net/http/contenttype_go1.13.go
+++ b/sdk/net/http/contenttype_go1.13.go
@@ -1,0 +1,35 @@
+// +build go1.13,!go1.14
+
+package http
+
+import (
+	"net/http"
+	"strings"
+)
+
+// shouldRecordBodyOfContentType checks if the body is meant
+// to be recorded based on the content-type and the fact that body is
+// not streamed.
+func shouldRecordBodyOfContentType(h http.Header) bool {
+	for _, contentTypeAllowed := range contentTypeAllowList {
+		lContentType := strings.ToLower(h.Get("content-type"))
+		// userland code can set joint headers directly instead of adding
+		// them for example
+		//
+		// ```
+		//   header.Set("content-type", "application/json; charset=utf-8")
+		// ```
+		//
+		// instead of
+		//
+		// ```
+		//    header.Add("content-type", "application/json")
+		//    header.Add("content-type", "charset=utf-8")
+		// ```
+		// hence we need to inspect it by using contains.
+		if strings.Contains(lContentType, contentTypeAllowed) {
+			return true
+		}
+	}
+	return false
+}

--- a/sdk/net/http/contenttype_go1.14.go
+++ b/sdk/net/http/contenttype_go1.14.go
@@ -1,0 +1,37 @@
+// +build go1.14
+
+package http
+
+import (
+	"net/http"
+	"strings"
+)
+
+// shouldRecordBodyOfContentType checks if the body is meant
+// to be recorded based on the content-type and the fact that body is
+// not streamed.
+func shouldRecordBodyOfContentType(h http.Header) bool {
+	for _, contentTypeAllowed := range contentTypeAllowList {
+		for _, contentType := range h.Values("content-type") {
+			lContentType := strings.ToLower(contentType)
+			// userland code can set joint headers directly instead of adding
+			// them for example
+			//
+			// ```
+			//   header.Set("content-type", "application/json; charset=utf-8")
+			// ```
+			//
+			// instead of
+			//
+			// ```
+			//    header.Add("content-type", "application/json")
+			//    header.Add("content-type", "charset=utf-8")
+			// ```
+			// hence we need to inspect it by using contains.
+			if strings.Contains(lContentType, contentTypeAllowed) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/sdk/net/http/contenttype_go1.14.go
+++ b/sdk/net/http/contenttype_go1.14.go
@@ -1,4 +1,6 @@
 // +build go1.14
+// http.Header.Values is available only in Go 1.14+. This API provides
+// full access to the list of headers.
 
 package http
 

--- a/sdk/net/http/contenttype_go1.14_test.go
+++ b/sdk/net/http/contenttype_go1.14_test.go
@@ -1,0 +1,27 @@
+// +build go1.14
+
+package http
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyLookupSuccessOnSetForReverseOrder(t *testing.T) {
+	tCases := []struct {
+		contentTypes []string
+		shouldRecord bool
+	}{
+		{[]string{"charset=utf-8", "application/json"}, true},
+	}
+
+	for _, tCase := range tCases {
+		h := http.Header{}
+		for _, header := range tCase.contentTypes {
+			h.Add("Content-Type", header)
+		}
+		assert.Equal(t, tCase.shouldRecord, shouldRecordBodyOfContentType(h))
+	}
+}

--- a/sdk/net/http/contenttype_test.go
+++ b/sdk/net/http/contenttype_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestKeyLookupSuccess(t *testing.T) {
+func TestKeyLookupSuccessOnSet(t *testing.T) {
 	tCases := []struct {
 		contentType  string
 		shouldRecord bool
@@ -15,12 +15,35 @@ func TestKeyLookupSuccess(t *testing.T) {
 		{"text/plain", false},
 		{"application/json", true},
 		{"Application/JSON", true},
+		{"application/json", true},
+		{"application/json; charset=utf-8", true},
 		{"application/x-www-form-urlencoded", true},
 	}
 
 	for _, tCase := range tCases {
 		h := http.Header{}
-		h.Add("Content-Type", tCase.contentType)
+		h.Set("Content-Type", tCase.contentType)
+		assert.Equal(t, tCase.shouldRecord, shouldRecordBodyOfContentType(h))
+	}
+}
+
+func TestKeyLookupSuccessOnAdd(t *testing.T) {
+	tCases := []struct {
+		contentTypes []string
+		shouldRecord bool
+	}{
+		{[]string{"text/plain"}, false},
+		{[]string{"application/json"}, true},
+		{[]string{"application/json", "charset=utf-8"}, true},
+		{[]string{"application/json; charset=utf-8"}, true},
+		{[]string{"application/x-www-form-urlencoded"}, true},
+	}
+
+	for _, tCase := range tCases {
+		h := http.Header{}
+		for _, header := range tCase.contentTypes {
+			h.Add("Content-Type", header)
+		}
 		assert.Equal(t, tCase.shouldRecord, shouldRecordBodyOfContentType(h))
 	}
 }

--- a/sdk/net/http/handler_test.go
+++ b/sdk/net/http/handler_test.go
@@ -179,7 +179,7 @@ func TestServerRecordsRequestAndResponseBodyAccordingly(t *testing.T) {
 			requestBody:                    "test_request_body",
 			responseBody:                   "test_response_body",
 			requestContentType:             "application/x-www-form-urlencoded",
-			responseContentType:            "Application/JSON",
+			responseContentType:            "application/json; charset=utf-8",
 			shouldHaveRecordedRequestBody:  true,
 			shouldHaveRecordedResponseBody: true,
 		},


### PR DESCRIPTION
Userland code can set multiheaders directly (separated by `;`) instead of using the Header.Add API. This requires to inspect the headers using contains rather than assert equal values.

Ping @davexroth 