### PR TITLE
always lowercase http header keys

### DIFF
--- a/instrumentation/opentelemetry/github.com/gorilla/hypermux/mux_test.go
+++ b/instrumentation/opentelemetry/github.com/gorilla/hypermux/mux_test.go
@@ -77,10 +77,10 @@ func TestSpanRecordedCorrectly(t *testing.T) {
 
 	attrs := internal.LookupAttributes(span.Attributes)
 	assert.Equal(t, "POST", attrs.Get("http.method").AsString())
-	assert.Equal(t, "abc123xyz", attrs.Get("http.request.header.Api_key").AsString())
+	assert.Equal(t, "abc123xyz", attrs.Get("http.request.header.api_key").AsString())
 	assert.Equal(t, `{"name":"Jacinto"}`, attrs.Get("http.request.body").AsString())
-	assert.Equal(t, "xyz123abc", attrs.Get("http.response.header.Request_id").AsString())
+	assert.Equal(t, "xyz123abc", attrs.Get("http.response.header.request_id").AsString())
 	assert.Equal(t, `{"id":123}`, attrs.Get("http.response.body").AsString())
-	assert.Equal(t, "application/json", attrs.Get("http.response.header.Content-Type[0]").AsString())
-	assert.Equal(t, "charset=utf-8", attrs.Get("http.response.header.Content-Type[1]").AsString())
+	assert.Equal(t, "application/json", attrs.Get("http.response.header.content-type[0]").AsString())
+	assert.Equal(t, "charset=utf-8", attrs.Get("http.response.header.content-type[1]").AsString())
 }

--- a/sdk/net/http/attributes.go
+++ b/sdk/net/http/attributes.go
@@ -3,6 +3,7 @@ package http
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/hypertrace/goagent/sdk"
 )
@@ -11,7 +12,7 @@ func setAttributesFromHeaders(_type string, headers http.Header, span sdk.Span) 
 	for key, values := range headers {
 		if len(values) == 1 {
 			span.SetAttribute(
-				fmt.Sprintf("http.%s.header.%s", _type, key),
+				fmt.Sprintf("http.%s.header.%s", _type, strings.ToLower(key)),
 				values[0],
 			)
 			continue
@@ -19,7 +20,7 @@ func setAttributesFromHeaders(_type string, headers http.Header, span sdk.Span) 
 
 		for index, value := range values {
 			span.SetAttribute(
-				fmt.Sprintf("http.%s.header.%s[%d]", _type, key, index),
+				fmt.Sprintf("http.%s.header.%s[%d]", _type, strings.ToLower(key), index),
 				value,
 			)
 		}

--- a/sdk/net/http/attributes_test.go
+++ b/sdk/net/http/attributes_test.go
@@ -13,7 +13,7 @@ func TestSetScalarAttributeSuccess(t *testing.T) {
 	h.Set("key_1", "value_1")
 	span := mock.NewSpan()
 	setAttributesFromHeaders("request", h, span)
-	assert.Equal(t, "value_1", span.ReadAttribute("http.request.header.Key_1").(string))
+	assert.Equal(t, "value_1", span.ReadAttribute("http.request.header.key_1").(string))
 
 	_ = span.ReadAttribute("container_id") // needed in containarized envs
 	assert.Zero(t, span.RemainingAttributes(), "unexpected remaining attribute: %v", span.Attributes)
@@ -27,8 +27,8 @@ func TestSetMultivalueAttributeSuccess(t *testing.T) {
 	span := mock.NewSpan()
 	setAttributesFromHeaders("response", h, span)
 
-	assert.Equal(t, "value_1", span.ReadAttribute("http.response.header.Key_1[0]").(string))
-	assert.Equal(t, "value_2", span.ReadAttribute("http.response.header.Key_1[1]").(string))
+	assert.Equal(t, "value_1", span.ReadAttribute("http.response.header.key_1[0]").(string))
+	assert.Equal(t, "value_2", span.ReadAttribute("http.response.header.key_1[1]").(string))
 
 	_ = span.ReadAttribute("container_id") // needed in containarized envs
 	assert.Zero(t, span.RemainingAttributes(), "unexpected remaining attribute: %v", span.Attributes)

--- a/sdk/net/http/handler_test.go
+++ b/sdk/net/http/handler_test.go
@@ -132,15 +132,15 @@ func TestServerRequestHeadersAreSuccessfullyRecorded(t *testing.T) {
 
 		span := spans[0]
 		if tCase.captureHTTPHeadersRequestConfig {
-			assert.Equal(t, "xyz123abc", span.ReadAttribute("http.request.header.Api_key").(string))
+			assert.Equal(t, "xyz123abc", span.ReadAttribute("http.request.header.api_key").(string))
 		} else {
 			assert.Nil(t, span.ReadAttribute("http.request.header.Api_key"))
 		}
 
 		if tCase.captureHTTPHeadersResponseConfig {
-			assert.Equal(t, "abc123xyz", span.ReadAttribute("http.response.header.Request_id").(string))
+			assert.Equal(t, "abc123xyz", span.ReadAttribute("http.response.header.request_id").(string))
 		} else {
-			assert.Nil(t, span.ReadAttribute("http.response.header.Request_id"))
+			assert.Nil(t, span.ReadAttribute("http.response.header.request_id"))
 		}
 	}
 }

--- a/sdk/net/http/transport_test.go
+++ b/sdk/net/http/transport_test.go
@@ -133,15 +133,15 @@ func TestClientRequestHeadersAreCapturedAccordingly(t *testing.T) {
 
 		span := spans[0]
 		if tCase.captureHTTPHeadersRequestConfig {
-			assert.Equal(t, "abc123xyz", span.ReadAttribute("http.request.header.Api_key").(string))
+			assert.Equal(t, "abc123xyz", span.ReadAttribute("http.request.header.api_key").(string))
 		} else {
 			assert.Nil(t, span.ReadAttribute("http.request.header.Api_key"))
 		}
 
 		if tCase.captureHTTPHeadersResponseConfig {
-			assert.Equal(t, "xyz123abc", span.ReadAttribute("http.response.header.Request_id").(string))
+			assert.Equal(t, "xyz123abc", span.ReadAttribute("http.response.header.request_id").(string))
 		} else {
-			assert.Nil(t, span.ReadAttribute("http.response.header.Request_id"))
+			assert.Nil(t, span.ReadAttribute("http.response.header.request_id"))
 		}
 	}
 }


### PR DESCRIPTION
better be consistent than not being consistent