### PR TITLE
Expose shouldRecordBodyOfContentType for use by other packages

### DIFF
--- a/sdk/net/http/contenttype.go
+++ b/sdk/net/http/contenttype.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"net/http"
 	"strings"
 )
 
@@ -14,8 +13,8 @@ var contentTypeAllowListLowerCase = []string{
 // shouldRecordBodyOfContentType checks if the body is meant
 // to be recorded based on the content-type and the fact that body is
 // not streamed.
-func shouldRecordBodyOfContentType(h http.Header) bool {
-	var contentTypeValues = h["Content-Type"] // "Content-Type" is the canonical key
+func ShouldRecordBodyOfContentType(h HeaderAccessor) bool {
+	var contentTypeValues = h.Lookup("Content-Type") // "Content-Type" is the canonical key
 
 	// we iterate all the values as userland code add the headers in the inverse order,
 	// e.g.

--- a/sdk/net/http/contenttype_test.go
+++ b/sdk/net/http/contenttype_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRecordingDecissionReturnsFalseOnNoContentType(t *testing.T) {
-	assert.Equal(t, false, shouldRecordBodyOfContentType(http.Header{"A": []string{"B"}}))
+	assert.Equal(t, false, ShouldRecordBodyOfContentType(headerMapAccessor{http.Header{"A": []string{"B"}}}))
 }
 
 func TestRecordingDecissionSuccessOnHeaderSet(t *testing.T) {
@@ -27,7 +27,7 @@ func TestRecordingDecissionSuccessOnHeaderSet(t *testing.T) {
 	for _, tCase := range tCases {
 		h := http.Header{}
 		h.Set("Content-Type", tCase.contentType)
-		assert.Equal(t, tCase.shouldRecord, shouldRecordBodyOfContentType(h))
+		assert.Equal(t, tCase.shouldRecord, ShouldRecordBodyOfContentType(headerMapAccessor{h}))
 	}
 }
 
@@ -49,6 +49,6 @@ func TestRecordingDecissionSuccessOnHeaderAdd(t *testing.T) {
 		for _, header := range tCase.contentTypes {
 			h.Add("Content-Type", header)
 		}
-		assert.Equal(t, tCase.shouldRecord, shouldRecordBodyOfContentType(h))
+		assert.Equal(t, tCase.shouldRecord, ShouldRecordBodyOfContentType(headerMapAccessor{h}))
 	}
 }

--- a/sdk/net/http/handler.go
+++ b/sdk/net/http/handler.go
@@ -54,7 +54,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// nil check for body is important as this block turns the body into another
 	// object that isn't nil and that will leverage the "Observer effect".
-	if r.Body != nil && h.dataCaptureConfig.HttpBody.Request.Value && shouldRecordBodyOfContentType(r.Header) {
+	if r.Body != nil && h.dataCaptureConfig.HttpBody.Request.Value && ShouldRecordBodyOfContentType(headerMapAccessor{r.Header}) {
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			return
@@ -77,7 +77,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		if h.dataCaptureConfig.HttpBody.Response.Value &&
 			len(wi.body) > 0 &&
-			shouldRecordBodyOfContentType(wi.Header()) {
+			ShouldRecordBodyOfContentType(headerMapAccessor{wi.Header()}) {
 			span.SetAttribute("http.response.body", string(wi.body))
 		}
 

--- a/sdk/net/http/headeraccessor.go
+++ b/sdk/net/http/headeraccessor.go
@@ -1,0 +1,19 @@
+package http
+
+// Interface for accessing http header values.
+//
+// Go packages use varying data structures and conventions for storing header key-values.
+// Using this interface allows us our functions to not be tied to a particular such format.
+type HeaderAccessor interface {
+	Lookup(key string) []string
+}
+
+type headerMapAccessor struct {
+	header map[string][]string
+}
+
+var _ HeaderAccessor = headerMapAccessor{}
+
+func (accessor headerMapAccessor) Lookup(key string) []string {
+	return accessor.header[key]
+}

--- a/sdk/net/http/transport.go
+++ b/sdk/net/http/transport.go
@@ -42,7 +42,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// is in the recording accept list. Notice in here we rely on the fact that
 	// the content type is not streamable, otherwise we could end up in a very
 	// expensive parsing of a big body in memory.
-	if rt.dataCaptureConfig.HttpBody.Request.Value && shouldRecordBodyOfContentType(req.Header) {
+	if rt.dataCaptureConfig.HttpBody.Request.Value && ShouldRecordBodyOfContentType(headerMapAccessor{req.Header}) {
 		body, err := ioutil.ReadAll(req.Body)
 		if err != nil {
 			return rt.delegate.RoundTrip(req)
@@ -62,7 +62,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	// Notice, parsing a streamed content in memory can be expensive.
-	if rt.dataCaptureConfig.HttpBody.Response.Value && shouldRecordBodyOfContentType(res.Header) {
+	if rt.dataCaptureConfig.HttpBody.Response.Value && ShouldRecordBodyOfContentType(headerMapAccessor{res.Header}) {
 		body, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			return res, nil


### PR DESCRIPTION
This will allow our ext-authz service to reuse the should-record logic.

Note envoy's protocol uses a [different format](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/attribute_context.proto#service-auth-v3-attributecontext-httprequest) for representing headers; hence, the addition of the HeaderAccessor interface.