### PR TITLE
Expose SetAttributesFromHeaders

### DIFF
--- a/sdk/net/http/attributes.go
+++ b/sdk/net/http/attributes.go
@@ -8,14 +8,14 @@ import (
 	"github.com/hypertrace/goagent/sdk"
 )
 
-func setAttributesFromHeaders(_type string, headers http.Header, span sdk.Span) {
-	for key, values := range headers {
+func SetAttributesFromHeaders(_type string, headers HeaderAccessor, span sdk.Span) {
+	headers.ForEachHeader(func(key string, values []string) error {
 		if len(values) == 1 {
 			span.SetAttribute(
 				fmt.Sprintf("http.%s.header.%s", _type, strings.ToLower(key)),
 				values[0],
 			)
-			continue
+			return nil
 		}
 
 		for index, value := range values {
@@ -24,5 +24,10 @@ func setAttributesFromHeaders(_type string, headers http.Header, span sdk.Span) 
 				value,
 			)
 		}
-	}
+		return nil
+	})
+}
+
+func setAttributesFromHeaders(_type string, headers http.Header, span sdk.Span) {
+	SetAttributesFromHeaders(_type, headerMapAccessor{headers}, span)
 }

--- a/sdk/net/http/headeraccessor.go
+++ b/sdk/net/http/headeraccessor.go
@@ -6,6 +6,8 @@ package http
 // Using this interface allows us our functions to not be tied to a particular such format.
 type HeaderAccessor interface {
 	Lookup(key string) []string
+
+	ForEachHeader(callback func(key string, values []string) error) error
 }
 
 type headerMapAccessor struct {
@@ -16,4 +18,14 @@ var _ HeaderAccessor = headerMapAccessor{}
 
 func (accessor headerMapAccessor) Lookup(key string) []string {
 	return accessor.header[key]
+}
+
+func (accessor headerMapAccessor) ForEachHeader(callback func(key string, values []string) error) error {
+	for key, values := range accessor.header {
+		err := callback(key, values)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Allows other packages to reuse the logic for setting header attributes. (Will be used by an authz service).