### PR TITLE
Support b3 for hypertrace

### DIFF
--- a/instrumentation/hypertrace/init.go
+++ b/instrumentation/hypertrace/init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hypertrace/goagent/config"
 	sdkconfig "github.com/hypertrace/goagent/sdk/config"
 	"github.com/hypertrace/goagent/version"
+	"go.opentelemetry.io/contrib/propagators/b3"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/trace/zipkin"
 	"go.opentelemetry.io/otel/propagation"
@@ -19,6 +20,22 @@ import (
 )
 
 const batchTimeoutInSecs = 200.0
+
+func makePropagator(formats []config.PropagationFormat) propagation.TextMapPropagator {
+	var propagators []propagation.TextMapPropagator
+	for _, format := range formats {
+		switch format {
+		case config.PropagationFormat_B3:
+			propagators = append(propagators, b3.B3{})
+		case config.PropagationFormat_TRACECONTEXT:
+			propagators = append(propagators, propagation.TraceContext{})
+		}
+	}
+	if len(propagators) == 0 {
+		return propagation.TraceContext{}
+	}
+	return propagation.NewCompositeTextMapPropagator(propagators...)
+}
 
 // Init initializes opentelemetry tracing and returns a shutdown function to flush data immediately
 // on a termination signal.
@@ -58,8 +75,7 @@ func Init(cfg *config.AgentConfig) func() {
 	}
 	otel.SetTracerProvider(tp)
 
-	// TODO: support configurable propagation
-	otel.SetTextMapPropagator(propagation.TraceContext{})
+	otel.SetTextMapPropagator(makePropagator(cfg.PropagationFormats))
 
 	// TODO: use batcher instead of this hack:
 	return func() {

--- a/instrumentation/hypertrace/init_test.go
+++ b/instrumentation/hypertrace/init_test.go
@@ -1,0 +1,38 @@
+package hypertrace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hypertrace/goagent/config"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel"
+)
+
+type carrier struct {
+	m map[string]string
+}
+
+func (c carrier) Get(string) string { return "" }
+
+func (c carrier) Set(key string, value string) {
+	c.m[key] = value
+}
+
+func TestPropagationFormats(t *testing.T) {
+	cfg := config.Load()
+	cfg.PropagationFormats = []config.PropagationFormat{
+		config.PropagationFormat_B3,
+		config.PropagationFormat_TRACECONTEXT,
+	}
+	Init(cfg)
+	tracer := otel.Tracer("b3")
+	ctx, _ := tracer.Start(context.Background(), "test")
+	propagator := otel.GetTextMapPropagator()
+	c := carrier{make(map[string]string)}
+	propagator.Inject(ctx, c)
+	_, ok := c.m["x-b3-traceid"]
+	assert.True(t, ok)
+	_, ok = c.m["traceparent"]
+	assert.True(t, ok)
+}


### PR DESCRIPTION
Supports b3 propagation format for hypertrace config.

There's probably a better way to organize the propagation code to get more reuse, but it wasn't clear to me how to fit that into to the current directory structure, so there's some duplication between the hypertrace and otel packages. 

Let me know if there's a better way to factor this.