### PR TITLE
chore(hypertrace): reuse opentelemetry Init in hypertrace package.

### DIFF
--- a/instrumentation/hypertrace/init.go
+++ b/instrumentation/hypertrace/init.go
@@ -1,72 +1,9 @@
 package hypertrace
 
 import (
-	"context"
-	"crypto/tls"
-	"log"
-	"net/http"
-	"time"
-
-	"github.com/hypertrace/goagent/config"
-	sdkconfig "github.com/hypertrace/goagent/sdk/config"
-	"github.com/hypertrace/goagent/version"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/trace/zipkin"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/semconv"
+	"github.com/hypertrace/goagent/instrumentation/opentelemetry"
 )
 
-const batchTimeoutInSecs = 200.0
-
-// Init initializes opentelemetry tracing and returns a shutdown function to flush data immediately
+// Init initializes hypertrace tracing and returns a shutdown function to flush data immediately
 // on a termination signal.
-func Init(cfg *config.AgentConfig) func() {
-	sdkconfig.InitConfig(cfg)
-
-	client := &http.Client{Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: !cfg.GetReporting().GetSecure().GetValue()},
-	}}
-
-	zipkinBatchExporter, err := zipkin.NewRawExporter(
-		cfg.GetReporting().GetEndpoint().GetValue(),
-		cfg.GetServiceName().GetValue(),
-		zipkin.WithClient(client),
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	resources, err := resource.New(context.Background(), resource.WithAttributes(
-		semconv.ServiceNameKey.String(cfg.GetServiceName().GetValue()),
-		semconv.TelemetrySDKNameKey.String("hypertrace"),
-		semconv.TelemetrySDKVersionKey.String(version.Version),
-	))
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
-		sdktrace.WithBatcher(zipkinBatchExporter, sdktrace.WithBatchTimeout(batchTimeoutInSecs*time.Millisecond)),
-		sdktrace.WithResource(resources),
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-	otel.SetTracerProvider(tp)
-
-	// TODO: support configurable propagation
-	otel.SetTextMapPropagator(propagation.TraceContext{})
-
-	// TODO: use batcher instead of this hack:
-	return func() {
-		// This is a sad temporary solution for the lack of flusher in the batcher interface.
-		// What we do here is that we wait for `batchTimeout` seconds as that is the time configured
-		// in the batcher and hence we make sure spans had time to be flushed.
-		// In next versions the flush functionality is finally added and we will use it.
-		<-time.After(batchTimeoutInSecs * 1.5 * time.Millisecond)
-	}
-}
+var Init = opentelemetry.Init


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
