### PR TITLE
feat(opentelemetry): makes sure shutdown reports all the spans on shu…

### DIFF
--- a/instrumentation/opencensus/span.go
+++ b/instrumentation/opencensus/span.go
@@ -45,9 +45,11 @@ func SpanFromContext(ctx context.Context) sdk.Span {
 	return &Span{trace.FromContext(ctx)}
 }
 
-func StartSpan(ctx context.Context, name string, options *sdk.SpanOptions) (context.Context, sdk.Span, func()) {
-	startOpts := []trace.StartOption{
-		trace.WithSpanKind(mapSpanKind(options.Kind)),
+func StartSpan(ctx context.Context, name string, opts *sdk.SpanOptions) (context.Context, sdk.Span, func()) {
+	startOpts := []trace.StartOption{}
+
+	if opts != nil {
+		startOpts = append(startOpts, trace.WithSpanKind(mapSpanKind(opts.Kind)))
 	}
 
 	ctx, span := trace.StartSpan(ctx, name, startOpts...)

--- a/instrumentation/opentelemetry/span.go
+++ b/instrumentation/opentelemetry/span.go
@@ -33,14 +33,16 @@ func SpanFromContext(ctx context.Context) sdk.Span {
 }
 
 func StartSpan(ctx context.Context, name string, opts *sdk.SpanOptions) (context.Context, sdk.Span, func()) {
-	startOpts := []trace.SpanOption{
-		trace.WithSpanKind(mapSpanKind(opts.Kind)),
-	}
+	startOpts := []trace.SpanOption{}
 
-	if opts.Timestamp.IsZero() {
-		startOpts = append(startOpts, trace.WithTimestamp(time.Now()))
-	} else {
-		startOpts = append(startOpts, trace.WithTimestamp(opts.Timestamp))
+	if opts != nil {
+		startOpts = append(startOpts, trace.WithSpanKind(mapSpanKind(opts.Kind)))
+
+		if opts.Timestamp.IsZero() {
+			startOpts = append(startOpts, trace.WithTimestamp(time.Now()))
+		} else {
+			startOpts = append(startOpts, trace.WithTimestamp(opts.Timestamp))
+		}
 	}
 
 	ctx, span := otel.Tracer(TracerDomain).Start(ctx, name, startOpts...)


### PR DESCRIPTION
This PR makes sure we flush all spans when we call the shutdown function. This is as opposed as the current approach which relies in timestamps.
