### PR TITLE
feat(config): adds load from env functionality to config.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,6 @@
+package config
+
+// LoadFromEnv loads env and default values on existing AgentConfig instance
+func (x *AgentConfig) LoadFromEnv() {
+	x.loadFromEnv("HT_", &defaultConfig)
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -79,7 +79,7 @@ func TestConfigLoadIsNotOverridenByDefaults(t *testing.T) {
 	assert.Equal(t, false, cfg.DataCapture.HttpHeaders.Request.Value)
 
 	cfg.LoadFromEnv()
-	// we verify here the value isn't overriden by default value (true)
+	// we verify here the value isn't overridden by default value (true)
 	assert.Equal(t, false, cfg.DataCapture.HttpHeaders.Request.Value)
 	// we verify default value is used for undefined value (true)
 	assert.Equal(t, true, cfg.DataCapture.HttpHeaders.Response.Value)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -81,4 +81,6 @@ func TestConfigLoadIsNotOverridenByDefaults(t *testing.T) {
 	cfg.LoadFromEnv()
 	// we verify here the value isn't overriden by default value (true)
 	assert.Equal(t, false, cfg.DataCapture.HttpHeaders.Request.Value)
+	// we verify default value is used for undefined value (true)
+	assert.Equal(t, true, cfg.DataCapture.HttpHeaders.Response.Value)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -70,17 +70,17 @@ func TestConfigLoadFromEnvOverridesWithEnv(t *testing.T) {
 func TestConfigLoadIsNotOverridenByDefaults(t *testing.T) {
 	cfg := &AgentConfig{
 		DataCapture: &DataCapture{
-			HttpHeaders: &Message{
+			RpcMetadata: &Message{
 				Request: Bool(false),
 			},
 		},
 	}
 
-	assert.Equal(t, false, cfg.DataCapture.HttpHeaders.Request.Value)
+	assert.Equal(t, false, cfg.DataCapture.RpcMetadata.Request.Value)
 
 	cfg.LoadFromEnv()
 	// we verify here the value isn't overridden by default value (true)
-	assert.Equal(t, false, cfg.DataCapture.HttpHeaders.Request.Value)
+	assert.Equal(t, false, cfg.DataCapture.RpcMetadata.Request.Value)
 	// we verify default value is used for undefined value (true)
-	assert.Equal(t, true, cfg.DataCapture.HttpHeaders.Response.Value)
+	assert.Equal(t, true, cfg.DataCapture.RpcMetadata.Response.Value)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -54,3 +54,31 @@ func TestSnakeYAMLLoadSuccess(t *testing.T) {
 	assert.Equal(t, "http://35.233.143.122:9411/api/v2/spans", cfg.GetReporting().GetEndpoint().GetValue())
 	assert.Equal(t, true, cfg.GetDataCapture().GetHttpHeaders().GetRequest().GetValue())
 }
+
+func TestConfigLoadFromEnvOverridesWithEnv(t *testing.T) {
+	cfg := &AgentConfig{
+		ServiceName: String("my_service"),
+	}
+	assert.Equal(t, "my_service", cfg.GetServiceName().Value)
+
+	os.Setenv("HT_SERVICE_NAME", "my_other_service")
+
+	cfg.LoadFromEnv()
+	assert.Equal(t, "my_other_service", cfg.GetServiceName().Value)
+}
+
+func TestConfigLoadIsNotOverridenByDefaults(t *testing.T) {
+	cfg := &AgentConfig{
+		DataCapture: &DataCapture{
+			HttpHeaders: &Message{
+				Request: Bool(false),
+			},
+		},
+	}
+
+	assert.Equal(t, false, cfg.DataCapture.HttpHeaders.Request.Value)
+
+	cfg.LoadFromEnv()
+	// we verify here the value isn't overriden by default value (true)
+	assert.Equal(t, false, cfg.DataCapture.HttpHeaders.Request.Value)
+}


### PR DESCRIPTION
Currently there is no way to load env and defaults from an existing config object and we need that when the config does not come from a config file.
