### PR TITLE
feat: Init tracer with resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/**
+.vscode/**
+instrumentation/hypertrace/google.golang.org/hypergrpc/examples/.DS_Store

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ func main() {
 
 Config values can be declared in config file, env variables or code. For further information about config check [this section](config/README.md).
 
+Immutable resource information for the env can be added by calling `hypertrace.InitWithResources(cfg)`
+
 ## Package net/hyperhttp
 
 ### HTTP server

--- a/instrumentation/hypertrace/init.go
+++ b/instrumentation/hypertrace/init.go
@@ -7,3 +7,5 @@ import (
 // Init initializes hypertrace tracing and returns a shutdown function to flush data immediately
 // on a termination signal.
 var Init = opentelemetry.Init
+
+var InitWithResources = opentelemetry.InitWithResources

--- a/instrumentation/opentelemetry/init_test.go
+++ b/instrumentation/opentelemetry/init_test.go
@@ -22,6 +22,18 @@ func ExampleInit() {
 	defer shutdown()
 }
 
+func ExampleInitWithResources() {
+	cfg := config.Load()
+	cfg.ServiceName = config.String("my_example_svc")
+	cfg.DataCapture.HttpHeaders.Request = config.Bool(true)
+	cfg.Reporting.Endpoint = config.String("http://api.traceable.ai:9411/api/v2/spans")
+
+	shutdown := InitWithResources(cfg, map[string]interface{}{
+		"example": "InitWithResources",
+	})
+	defer shutdown()
+}
+
 func TestShutdownFlushesAllSpans(t *testing.T) {
 	requestIsReceived := false
 	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Extended hypertrace Init with a new API InitWithResources
which defines immutable resources in the case of otel tracer

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
