### PR TITLE
configured propagation formats ignored

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -29,6 +29,19 @@ Supported formats for config files are YAML and JSON.
 
 All default values are defined in the [defaults.go](./defaults.go), everything else will be default to zero values.
 
+## Loading for existing config
+
+Sometimes the user can choose to populate the config object and then load the config values
+from environment variables. In such case one can run:
+
+```go
+cfg := &config.AgentConfig{}
+cfg.ServiceName = config.String("myservice")
+cfg.DataCapture.HTTPHeaders.Request = config.Bool(true)
+
+cfg.LoadFromEnv()
+```
+
 ## Generating config structs
 
 When changing the proto definition, the config structs must be regenerated to use the new configuration fields. This can be done by:

--- a/config/cmd/generator/main.go
+++ b/config/cmd/generator/main.go
@@ -149,7 +149,7 @@ Parse PROTO_FILE and generate output value objects`)
 
 					c += fmt.Sprintf("        x.%s = vals\n", fieldName)
 				}
-				c += fmt.Sprintf("    } else if len(defaultValues.%s) > 0 {\n", fieldName)
+				c += fmt.Sprintf("    } else if len(x.%s) == 0 && len(defaultValues.%s) > 0 {\n", fieldName, fieldName)
 				c += fmt.Sprintf("        x.%s = defaultValues.%s\n", fieldName, fieldName)
 				c += fmt.Sprintf("    }\n\n")
 			} else if strings.HasPrefix(fieldType, "google.protobuf.") {

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 // LoadFromEnv loads env and default values on existing AgentConfig instance
+// where defaults only overrides empty values while env vars can override all
+// of them.
 func (x *AgentConfig) LoadFromEnv() {
 	x.loadFromEnv("HT_", &defaultConfig)
 }

--- a/config/config.pbloader.go
+++ b/config/config.pbloader.go
@@ -30,8 +30,10 @@ func (x *AgentConfig) loadFromEnv(prefix string, defaultValues *AgentConfig) {
 			vals = append(vals, PropagationFormat(PropagationFormat_value[rawVal]))
 		}
 		x.PropagationFormats = vals
-	} else if len(defaultValues.PropagationFormats) > 0 {
-		x.PropagationFormats = defaultValues.PropagationFormats
+	} else if len(x.PropagationFormats) == 0 {
+		if len(defaultValues.PropagationFormats) > 0 {
+			x.PropagationFormats = defaultValues.PropagationFormats
+		}
 	}
 
 	if val, ok := getBoolEnv(prefix + "ENABLED"); ok {

--- a/config/config.pbloader.go
+++ b/config/config.pbloader.go
@@ -30,10 +30,8 @@ func (x *AgentConfig) loadFromEnv(prefix string, defaultValues *AgentConfig) {
 			vals = append(vals, PropagationFormat(PropagationFormat_value[rawVal]))
 		}
 		x.PropagationFormats = vals
-	} else if len(x.PropagationFormats) == 0 {
-		if len(defaultValues.PropagationFormats) > 0 {
-			x.PropagationFormats = defaultValues.PropagationFormats
-		}
+	} else if len(x.PropagationFormats) == 0 && len(defaultValues.PropagationFormats) > 0 {
+		x.PropagationFormats = defaultValues.PropagationFormats
 	}
 
 	if val, ok := getBoolEnv(prefix + "ENABLED"); ok {
@@ -51,7 +49,7 @@ func (x *AgentConfig) loadFromEnv(prefix string, defaultValues *AgentConfig) {
 			x.ResourceAttributes = make(map[string]string)
 		}
 		for k, v := range defaultValues.ResourceAttributes {
-			// defaults should not override existing resources unless empty
+			// defaults should not override existing resource attributes unless empty
 			if _, ok := x.ResourceAttributes[k]; !ok {
 				x.ResourceAttributes[k] = v
 			}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -57,23 +57,31 @@ func TestSnakeYAMLLoadSuccess(t *testing.T) {
 
 func TestConfigLoadFromEnvOverridesWithEnv(t *testing.T) {
 	cfg := &AgentConfig{
-		ServiceName: String("my_service"),
+		ServiceName:        String("my_service"),
+		PropagationFormats: []PropagationFormat{PropagationFormat_B3, PropagationFormat_TRACECONTEXT},
 	}
 	assert.Equal(t, "my_service", cfg.GetServiceName().Value)
 
 	os.Setenv("HT_SERVICE_NAME", "my_other_service")
+	os.Setenv("HT_PROPAGATION_FORMATS", "B3")
 
 	cfg.LoadFromEnv()
 	assert.Equal(t, "my_other_service", cfg.GetServiceName().Value)
+	assert.Equal(t, 1, len(cfg.GetPropagationFormats()))
+	assert.Equal(t, PropagationFormat_B3, cfg.GetPropagationFormats()[0])
 }
 
 func TestConfigLoadIsNotOverridenByDefaults(t *testing.T) {
+	pf := []PropagationFormat{
+		PropagationFormat_B3, PropagationFormat_TRACECONTEXT}
+
 	cfg := &AgentConfig{
 		DataCapture: &DataCapture{
 			RpcMetadata: &Message{
 				Request: Bool(false),
 			},
 		},
+		PropagationFormats: pf,
 	}
 
 	assert.Equal(t, false, cfg.DataCapture.RpcMetadata.Request.Value)
@@ -83,4 +91,5 @@ func TestConfigLoadIsNotOverridenByDefaults(t *testing.T) {
 	assert.Equal(t, false, cfg.DataCapture.RpcMetadata.Request.Value)
 	// we verify default value is used for undefined value (true)
 	assert.Equal(t, true, cfg.DataCapture.RpcMetadata.Response.Value)
+	assert.ElementsMatch(t, pf, cfg.GetPropagationFormats())
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,15 +7,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// A number of these tests set environment variables.
+// When setting an env var, ensure that it is unset
+// at the end of the test so as not to impact other tests
+
 func TestSourcesPrecedence(t *testing.T) {
 	// defines the config file path
 	os.Setenv("HT_CONFIG_FILE", "./testdata/config.json")
+	defer os.Unsetenv("HT_CONFIG_FILE")
 
 	// defines the DataCapture.HTTPHeaders.Request = true
 	os.Setenv("HT_DATA_CAPTURE_HTTP_HEADERS_REQUEST", "true")
+	defer os.Unsetenv("HT_DATA_CAPTURE_HTTP_HEADERS_REQUEST")
 
 	// defines the DataCapture.HTTPHeaders.Request = false
 	os.Setenv("HT_DATA_CAPTURE_HTTP_HEADERS_RESPONSE", "false")
+	defer os.Unsetenv("HT_DATA_CAPTURE_HTTP_HEADERS_RESPONSE")
 
 	// loads the config
 	cfg := Load()
@@ -32,7 +39,6 @@ func TestSourcesPrecedence(t *testing.T) {
 
 	// static value take precedence over config files
 	assert.Equal(t, false, cfg.GetDataCapture().GetRpcMetadata().GetResponse().GetValue())
-
 }
 
 func TestCamelYAMLLoadSuccess(t *testing.T) {
@@ -63,7 +69,9 @@ func TestConfigLoadFromEnvOverridesWithEnv(t *testing.T) {
 	assert.Equal(t, "my_service", cfg.GetServiceName().Value)
 
 	os.Setenv("HT_SERVICE_NAME", "my_other_service")
+	defer os.Unsetenv("HT_SERVICE_NAME")
 	os.Setenv("HT_PROPAGATION_FORMATS", "B3")
+	defer os.Unsetenv("HT_PROPAGATION_FORMATS")
 
 	cfg.LoadFromEnv()
 	assert.Equal(t, "my_other_service", cfg.GetServiceName().Value)


### PR DESCRIPTION
## Description
If the propagation formats were defined in the config file, there were getting overwritten by the default value.

### Checklist:
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules
