### PR TITLE
feat: Add support for multiple tracer providers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,14 +7,12 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.4.3
 	github.com/gorilla/mux v1.6.2
-	github.com/iancoleman/strcase v0.1.3 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.4
 	github.com/ngrok/sqlmw v0.0.0-20200129213757-d5c93a81bec6
 	github.com/openzipkin/zipkin-go v0.2.5
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.7.0
-	github.com/tallstoat/pbparser v0.2.0 // indirect
 	go.opencensus.io v0.22.4
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.16.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,6 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/iancoleman/strcase v0.1.3 h1:dJBk1m2/qjL1twPLf68JND55vvivMupZ4wIzE8CTdBw=
-github.com/iancoleman/strcase v0.1.3/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -95,8 +93,6 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tallstoat/pbparser v0.2.0 h1:lsFH4mdiOv1MIQVmge/idThSTd2uByNodWVfbtysjzg=
-github.com/tallstoat/pbparser v0.2.0/go.mod h1:aUC6W9uQLeAXZkknve8ZDO6InhRYpYHlJ9kvsQh1i2k=
 go.opencensus.io v0.22.4 h1:LYy1Hy3MJdrCdMwwzxA/dRok4ejH+RwNGbuoD9fCjto=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opentelemetry.io/contrib v0.16.0 h1:cScR/U3bjTjxsBv939wh4miANY/akdP644rsg9msrIA=

--- a/instrumentation/hypertrace/init.go
+++ b/instrumentation/hypertrace/init.go
@@ -8,4 +8,4 @@ import (
 // on a termination signal.
 var Init = opentelemetry.Init
 
-var InitService = opentelemetry.InitService
+var RegisterService = opentelemetry.RegisterService

--- a/instrumentation/hypertrace/init.go
+++ b/instrumentation/hypertrace/init.go
@@ -7,3 +7,5 @@ import (
 // Init initializes hypertrace tracing and returns a shutdown function to flush data immediately
 // on a termination signal.
 var Init = opentelemetry.Init
+
+var InitService = opentelemetry.InitService

--- a/instrumentation/opentelemetry/database/hypersql/sql_test.go
+++ b/instrumentation/opentelemetry/database/hypersql/sql_test.go
@@ -89,6 +89,8 @@ func TestExecSuccess(t *testing.T) {
 
 	attrs := internal.LookupAttributes(span.Attributes)
 	assert.False(t, attrs.Has("error"))
+
+	db.Close()
 }
 
 func TestTxWithCommitSuccess(t *testing.T) {

--- a/instrumentation/opentelemetry/init.go
+++ b/instrumentation/opentelemetry/init.go
@@ -3,6 +3,7 @@ package opentelemetry
 import (
 	"context"
 	"fmt"
+	"go.opentelemetry.io/otel/trace"
 	"log"
 	"net/http"
 	"sync"
@@ -149,5 +150,7 @@ func RegisterService(serviceName string, resourceAttributes map[string]string) (
 	)
 
 	traceProviders[serviceName] = tp
-	return startSpan(tp), nil
+	return startSpan(func() trace.TracerProvider {
+		return tp
+	}), nil
 }

--- a/instrumentation/opentelemetry/init.go
+++ b/instrumentation/opentelemetry/init.go
@@ -128,6 +128,7 @@ func createResources(serviceName string, resources map[string]string) []label.Ke
 	return retValues
 }
 
+// RegisterService creates tracerprovider for a new service and returns a func which can be used to create spans
 func RegisterService(serviceName string, resourceAttributes map[string]string) (sdk.StartSpan, error) {
 	mu.Lock()
 	defer mu.Unlock()

--- a/instrumentation/opentelemetry/init.go
+++ b/instrumentation/opentelemetry/init.go
@@ -2,14 +2,17 @@ package opentelemetry
 
 import (
 	"context"
+	"fmt"
+	"github.com/hypertrace/goagent/sdk"
+	"go.opentelemetry.io/otel/trace"
 	"log"
 	"net/http"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/label"
 
 	"crypto/tls"
-
 	"github.com/hypertrace/goagent/config"
 	sdkconfig "github.com/hypertrace/goagent/sdk/config"
 	"github.com/hypertrace/goagent/version"
@@ -17,12 +20,26 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/trace/zipkin"
 	"go.opentelemetry.io/otel/propagation"
+	sdkexport "go.opentelemetry.io/otel/sdk/export/trace"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/semconv"
 )
 
 var batchTimeout = time.Duration(200) * time.Millisecond
+
+type traceProviderWrapper struct {
+	tp       trace.TracerProvider
+	shutdown func()
+}
+
+var (
+	traceProviders map[string]*traceProviderWrapper
+	batcher        sdkexport.SpanExporter
+	sampler        sdktrace.Sampler
+	initialized    = false
+	mu             sync.Mutex
+)
 
 func makePropagator(formats []config.PropagationFormat) propagation.TextMapPropagator {
 	var propagators []propagation.TextMapPropagator
@@ -43,6 +60,11 @@ func makePropagator(formats []config.PropagationFormat) propagation.TextMapPropa
 // Init initializes opentelemetry tracing and returns a shutdown function to flush data immediately
 // on a termination signal.
 func Init(cfg *config.AgentConfig) func() {
+	mu.Lock()
+	defer mu.Unlock()
+	if initialized {
+		return func() {}
+	}
 	sdkconfig.InitConfig(cfg)
 
 	client := &http.Client{Transport: &http.Transport{
@@ -61,14 +83,14 @@ func Init(cfg *config.AgentConfig) func() {
 
 	resources, err := resource.New(
 		context.Background(),
-		resource.WithAttributes(makeResources(cfg)...),
+		resource.WithAttributes(createResources(cfg.GetServiceName().GetValue(), cfg.ResourceAttributes)...),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
-
+	defaultSampler := sdktrace.AlwaysSample()
 	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
+		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: defaultSampler}),
 		sdktrace.WithBatcher(zipkinBatchExporter, sdktrace.WithBatchTimeout(batchTimeout)),
 		sdktrace.WithResource(resources),
 	)
@@ -76,20 +98,64 @@ func Init(cfg *config.AgentConfig) func() {
 
 	otel.SetTextMapPropagator(makePropagator(cfg.PropagationFormats))
 
+	batcher = zipkinBatchExporter
+	traceProviders = make(map[string]*traceProviderWrapper)
+	sampler = defaultSampler
+	initialized = true
 	return func() {
+		mu.Lock()
+		defer mu.Unlock()
+		// TODO: There is an issue here. The traceprovider which is shutdown first, will only have its span flushed.
+		for _, wrapper := range traceProviders {
+			wrapper.shutdown()
+		}
 		tp.Shutdown(context.Background())
+		initialized = false
 	}
 }
 
-func makeResources(cfg *config.AgentConfig) []label.KeyValue {
+func createResources(serviceName string, resources map[string]string) []label.KeyValue {
 	retValues := []label.KeyValue{
-		semconv.ServiceNameKey.String(cfg.GetServiceName().GetValue()),
+		semconv.ServiceNameKey.String(serviceName),
 		semconv.TelemetrySDKNameKey.String("hypertrace"),
 		semconv.TelemetrySDKVersionKey.String(version.Version),
 	}
 
-	for k, v := range cfg.ResourceAttributes {
+	for k, v := range resources {
 		retValues = append(retValues, label.String(k, v))
 	}
 	return retValues
+}
+
+func InitService(serviceName string, resourceAttributes map[string]string) (sdk.StartSpan, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	if !initialized {
+		return nil, fmt.Errorf("hypertrace lib not initialized. hypertrace.Init has not been called")
+	}
+
+	if _, ok := traceProviders[serviceName]; ok {
+		return nil, fmt.Errorf("service %v already initialized", serviceName)
+	}
+
+	resources, err := resource.New(
+		context.Background(),
+		resource.WithAttributes(createResources(serviceName, resourceAttributes)...),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sampler}),
+		sdktrace.WithBatcher(batcher, sdktrace.WithBatchTimeout(batchTimeout)),
+		sdktrace.WithResource(resources),
+	)
+
+	traceProviders[serviceName] = &traceProviderWrapper{
+		tp: tp,
+		shutdown: func() {
+			tp.Shutdown(context.Background())
+		},
+	}
+	return startSpan(tp), nil
 }

--- a/instrumentation/opentelemetry/init.go
+++ b/instrumentation/opentelemetry/init.go
@@ -3,16 +3,17 @@ package opentelemetry
 import (
 	"context"
 	"fmt"
-	"github.com/hypertrace/goagent/sdk"
-	"go.opentelemetry.io/otel/trace"
 	"log"
 	"net/http"
 	"sync"
 	"time"
 
+	"github.com/hypertrace/goagent/sdk"
+
 	"go.opentelemetry.io/otel/label"
 
 	"crypto/tls"
+
 	"github.com/hypertrace/goagent/config"
 	sdkconfig "github.com/hypertrace/goagent/sdk/config"
 	"github.com/hypertrace/goagent/version"
@@ -28,7 +29,7 @@ import (
 var batchTimeout = time.Duration(200) * time.Millisecond
 
 type traceProviderWrapper struct {
-	tp       trace.TracerProvider
+	tp       *sdktrace.TracerProvider
 	shutdown func()
 }
 

--- a/instrumentation/opentelemetry/init_test.go
+++ b/instrumentation/opentelemetry/init_test.go
@@ -24,7 +24,7 @@ func ExampleInit() {
 	defer shutdown()
 }
 
-func ExampleInitService() {
+func ExampleRegisterService() {
 	cfg := config.Load()
 	cfg.ServiceName = config.String("my_example_svc")
 	cfg.DataCapture.HttpHeaders.Request = config.Bool(true)
@@ -34,7 +34,7 @@ func ExampleInitService() {
 
 	_, err := RegisterService("custom_service", map[string]string{"test1": "val1"})
 	if err != nil {
-		log.Fatalf("Error while initalizing service: %v", err)
+		log.Fatalf("Error while initializing service: %v", err)
 	}
 
 	defer shutdown()

--- a/instrumentation/opentelemetry/init_test.go
+++ b/instrumentation/opentelemetry/init_test.go
@@ -75,7 +75,6 @@ func TestMultipleTraceProviders(t *testing.T) {
 
 	cfg := config.Load()
 	cfg.ServiceName = config.String("my_example_svc")
-	fmt.Println(srv.URL)
 	cfg.Reporting.Endpoint = config.String(srv.URL)
 
 	// By doing this we make sure a batching isn't happening

--- a/instrumentation/opentelemetry/init_test.go
+++ b/instrumentation/opentelemetry/init_test.go
@@ -95,6 +95,7 @@ func TestMultipleTraceProviders(t *testing.T) {
 	assert.False(t, requestIsReceived)
 	shutdown()
 	assert.True(t, requestIsReceived)
+	assert.Equal(t, 0, len(traceProviders))
 }
 
 func TestMultipleTraceProvidersCallAfterShutdown(t *testing.T) {

--- a/instrumentation/opentelemetry/init_test.go
+++ b/instrumentation/opentelemetry/init_test.go
@@ -2,6 +2,7 @@ package opentelemetry
 
 import (
 	"context"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -22,6 +23,22 @@ func ExampleInit() {
 	defer shutdown()
 }
 
+func ExampleInitService() {
+	cfg := config.Load()
+	cfg.ServiceName = config.String("my_example_svc")
+	cfg.DataCapture.HttpHeaders.Request = config.Bool(true)
+	cfg.Reporting.Endpoint = config.String("http://api.traceable.ai:9411/api/v2/spans")
+
+	shutdown := Init(cfg)
+
+	_, err := InitService("custom_service", map[string]string{"test1": "val1"})
+	if err != nil {
+		log.Fatalf("Error while initalizing service: %v", err)
+	}
+
+	defer shutdown()
+}
+
 func TestShutdownFlushesAllSpans(t *testing.T) {
 	requestIsReceived := false
 	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
@@ -37,8 +54,42 @@ func TestShutdownFlushesAllSpans(t *testing.T) {
 	batchTimeout = time.Duration(10) * time.Second
 
 	shutdown := Init(cfg)
+	assert.True(t, initialized)
+	assert.Equal(t, 0, len(traceProviders))
 
 	_, _, spanEnder := StartSpan(context.Background(), "my_span", nil)
+	spanEnder()
+
+	assert.False(t, requestIsReceived)
+	shutdown()
+	assert.True(t, requestIsReceived)
+}
+
+func TestMultipleTraceProviders(t *testing.T) {
+	requestIsReceived := false
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		requestIsReceived = true
+	}))
+	defer srv.Close()
+
+	cfg := config.Load()
+	cfg.ServiceName = config.String("my_example_svc")
+	cfg.Reporting.Endpoint = config.String(srv.URL)
+
+	// By doing this we make sure a batching isn't happening
+	batchTimeout = time.Duration(10) * time.Second
+
+	shutdown := Init(cfg)
+	assert.True(t, initialized)
+	assert.Equal(t, 0, len(traceProviders))
+
+	startServiceSpan, err := InitService("custom_service", map[string]string{"test1": "val1"})
+	assert.NoError(t, err)
+	assert.NotNil(t, startServiceSpan)
+	assert.True(t, initialized)
+	assert.Equal(t, 1, len(traceProviders))
+
+	_, _, spanEnder := startServiceSpan(context.Background(), "my_span", nil)
 	spanEnder()
 
 	assert.False(t, requestIsReceived)

--- a/instrumentation/opentelemetry/span.go
+++ b/instrumentation/opentelemetry/span.go
@@ -32,22 +32,28 @@ func SpanFromContext(ctx context.Context) sdk.Span {
 	return &Span{trace.SpanFromContext(ctx)}
 }
 
-func StartSpan(ctx context.Context, name string, opts *sdk.SpanOptions) (context.Context, sdk.Span, func()) {
-	startOpts := []trace.SpanOption{}
+//type StartServiceSpan func(context.Context, string, *sdk.SpanOptions) (context.Context, sdk.Span, func())
 
-	if opts != nil {
-		startOpts = append(startOpts, trace.WithSpanKind(mapSpanKind(opts.Kind)))
+func startSpan(tp trace.TracerProvider) sdk.StartSpan {
+	return func(ctx context.Context, name string, opts *sdk.SpanOptions) (context.Context, sdk.Span, func()) {
+		startOpts := []trace.SpanOption{}
 
-		if opts.Timestamp.IsZero() {
-			startOpts = append(startOpts, trace.WithTimestamp(time.Now()))
-		} else {
-			startOpts = append(startOpts, trace.WithTimestamp(opts.Timestamp))
+		if opts != nil {
+			startOpts = append(startOpts, trace.WithSpanKind(mapSpanKind(opts.Kind)))
+
+			if opts.Timestamp.IsZero() {
+				startOpts = append(startOpts, trace.WithTimestamp(time.Now()))
+			} else {
+				startOpts = append(startOpts, trace.WithTimestamp(opts.Timestamp))
+			}
 		}
-	}
 
-	ctx, span := otel.Tracer(TracerDomain).Start(ctx, name, startOpts...)
-	return ctx, &Span{span}, func() { span.End() }
+		ctx, span := tp.Tracer(TracerDomain).Start(ctx, name, startOpts...)
+		return ctx, &Span{span}, func() { span.End() }
+	}
 }
+
+var StartSpan = startSpan(otel.GetTracerProvider())
 
 func mapSpanKind(kind sdk.SpanKind) trace.SpanKind {
 	switch kind {

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -9,3 +9,8 @@ import (
 func InitConfig(c *config.AgentConfig) {
 	internalconfig.InitConfig(c)
 }
+
+// InitConfig allows users to initialize the config
+func GetConfig() *config.AgentConfig {
+	return internalconfig.GetConfig()
+}

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -9,3 +9,11 @@ import (
 func InitConfig(c *config.AgentConfig) {
 	internalconfig.InitConfig(c)
 }
+
+func GetReportingEndpointConfig() string {
+	return internalconfig.GetConfig().GetReporting().GetEndpoint().GetValue()
+}
+
+func GetReportingSecureConfig() bool {
+	return internalconfig.GetConfig().GetReporting().GetSecure().GetValue()
+}

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -9,11 +9,3 @@ import (
 func InitConfig(c *config.AgentConfig) {
 	internalconfig.InitConfig(c)
 }
-
-func GetReportingEndpointConfig() string {
-	return internalconfig.GetConfig().GetReporting().GetEndpoint().GetValue()
-}
-
-func GetReportingSecureConfig() bool {
-	return internalconfig.GetConfig().GetReporting().GetSecure().GetValue()
-}

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -9,8 +9,3 @@ import (
 func InitConfig(c *config.AgentConfig) {
 	internalconfig.InitConfig(c)
 }
-
-// InitConfig allows users to initialize the config
-func GetConfig() *config.AgentConfig {
-	return internalconfig.GetConfig()
-}


### PR DESCRIPTION
Added InitService which internally creates a new TracerProvider
used for creating services with a different set of resource attributes
then the default service.
