### PR TITLE
fix: fixes request body handling for it to be nil in transport.

### DIFF
--- a/sdk/instrumentation/net/http/transport.go
+++ b/sdk/instrumentation/net/http/transport.go
@@ -42,7 +42,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// is in the recording accept list. Notice in here we rely on the fact that
 	// the content type is not streamable, otherwise we could end up in a very
 	// expensive parsing of a big body in memory.
-	if rt.dataCaptureConfig.HttpBody.Request.Value && ShouldRecordBodyOfContentType(headerMapAccessor{req.Header}) {
+	if req.Body != nil && rt.dataCaptureConfig.HttpBody.Request.Value && ShouldRecordBodyOfContentType(headerMapAccessor{req.Header}) {
 		body, err := ioutil.ReadAll(req.Body)
 		if err != nil {
 			return rt.delegate.RoundTrip(req)


### PR DESCRIPTION
## Description

This PR fixes the case there the request body is `nil` as we were trying to read it without such check.

Ping @samarth-gupta-traceable 
