### PR TITLE
fix: Update http handler to record host

### DIFF
--- a/sdk/instrumentation/net/http/handler.go
+++ b/sdk/instrumentation/net/http/handler.go
@@ -59,6 +59,9 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	url := r.URL.String()
 	span.SetAttribute("http.url", url)
 
+	host := r.Host
+	span.SetAttribute("http.request.header.host", host)
+
 	headers := r.Header
 	// Sets an attribute per each request header.
 	if h.dataCaptureConfig.HttpHeaders.Request.Value {

--- a/sdk/instrumentation/net/http/handler_test.go
+++ b/sdk/instrumentation/net/http/handler_test.go
@@ -27,7 +27,6 @@ func (h *mockHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	h.baseHandler.ServeHTTP(rw, r.WithContext(ctx))
 }
 
-
 func TestServerRequestWithNilBodyIsntChanged(t *testing.T) {
 	h := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		assert.Nil(t, r.Body)

--- a/sdk/instrumentation/net/http/handler_test.go
+++ b/sdk/instrumentation/net/http/handler_test.go
@@ -88,6 +88,7 @@ func TestServerRequestIsSuccessfullyTraced(t *testing.T) {
 
 	span := ih.spans[0]
 	assert.Equal(t, "http://traceable.ai/foo?user_id=1", span.ReadAttribute("http.url").(string))
+	assert.Equal(t, "traceable.ai", span.ReadAttribute("http.request.header.host"))
 
 	_ = span.ReadAttribute("container_id") // needed in containarized envs
 	assert.Zero(t, span.RemainingAttributes(), "unexpected remaining attribute: %v", span.Attributes)


### PR DESCRIPTION
## Description
The go http package copies the http host header to `request.Host` field and deletes the header from the map.
This change allows us to record the http host.

https://github.com/golang/go/blob/ab4085ce84f8378b4ec2dfdbbc44c98cb92debe5/src/net/http/request.go#L154-L155

The above behavior prevents `SetAttributesFromHeaders` method from being able to record the host header.



### Testing
The new test asserts that `request.Host` is added to the spans attributes.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

