### PR TITLE
fix: Always report rpc method & scheme

### DIFF
--- a/instrumentation/hypertrace/google.golang.org/hypergrpc/examples/helloworld/helloworldv1.pb.go
+++ b/instrumentation/hypertrace/google.golang.org/hypergrpc/examples/helloworld/helloworldv1.pb.go
@@ -1,0 +1,52 @@
+package helloworld
+
+import proto "github.com/golang/protobuf/proto"
+import fmt "fmt"
+import math "math"
+
+// Reference imports to suppress errors if they are not otherwise used.
+var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
+
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+// A compilation error at this line likely means your copy of the
+// proto package needs to be updated.
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+
+type HelloResponse struct {
+	Name            string   `protobuf:"bytes,1,opt,name=name,json=name,proto3" json:"product_id,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *HelloResponse) Reset()         { *m = HelloResponse{} }
+func (m *HelloResponse) String() string { return proto.CompactTextString(m) }
+func (*HelloResponse) ProtoMessage()    {}
+
+func (m *HelloResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CartItem.Unmarshal(m, b)
+}
+func (m *HelloResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CartItem.Marshal(b, m, deterministic)
+}
+func (dst *HelloResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CartItem.Merge(dst, src)
+}
+func (m *HelloResponse) XXX_Size() int {
+	return xxx_messageInfo_CartItem.Size(m)
+}
+func (m *HelloResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_CartItem.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_CartItem proto.InternalMessageInfo
+
+func (m *HelloResponse) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}

--- a/sdk/instrumentation/google.golang.org/grpc/serializer.go
+++ b/sdk/instrumentation/google.golang.org/grpc/serializer.go
@@ -1,18 +1,18 @@
 package grpc
 
 import (
+	"github.com/golang/protobuf/proto"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 )
 
-// We need a marshaller that does not omit the zero (e.g. 0 or false) to not to lose pontetially
-// intesting information.
+// We need a marshaller that does not omit the zero (e.g. 0 or false) to not to lose potentially
+// interesting information.
 var marshaler = protojson.MarshalOptions{EmitUnpopulated: false}
 
 // MarshalMessageableJSON marshals a value that an be cast as proto.Message into JSON.
 func marshalMessageableJSON(messageable interface{}) ([]byte, error) {
-	if m, ok := messageable.(proto.Message); ok {
-		return marshaler.Marshal(m)
+	if msg, ok := messageable.(proto.Message); ok {
+		return marshaler.Marshal(proto.MessageV2(msg))
 	}
 
 	return nil, nil

--- a/sdk/instrumentation/google.golang.org/grpc/serializer_test.go
+++ b/sdk/instrumentation/google.golang.org/grpc/serializer_test.go
@@ -1,0 +1,22 @@
+package grpc
+
+import (
+	"testing"
+
+	pb "github.com/hypertrace/goagent/instrumentation/hypertrace/google.golang.org/hypergrpc/examples/helloworld"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithProtobufMessageFormatV2(t *testing.T) {
+	msg := &pb.HelloReply{Message: "Test Message"}
+	data, err := marshalMessageableJSON(msg)
+	assert.Nil(t, err)
+	assert.Equal(t, "{\"message\":\"Test Message\"}", string(data[:]))
+}
+
+func TestWithProtobufMessageFormatV1(t *testing.T) {
+	msg := &pb.HelloResponse{Name: "Test Name"}
+	data, err := marshalMessageableJSON(msg)
+	assert.Nil(t, err)
+	assert.Equal(t, "{\"name\":\"Test Name\"}", string(data[:]))
+}

--- a/sdk/instrumentation/google.golang.org/grpc/server.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 )
@@ -83,6 +84,17 @@ func wrapHandler(
 		pieces := strings.Split(fullMethod[1:], "/")
 		span.SetAttribute("rpc.service", pieces[0])
 		span.SetAttribute("rpc.method", pieces[1])
+
+		span.SetAttribute("rpc.request.metadata.:method", "POST")
+
+		peer, ok := peer.FromContext(ctx)
+		if ok {
+			if peer.AuthInfo == nil {
+				span.SetAttribute("rpc.request.metadata.:scheme", "http")
+			} else {
+				span.SetAttribute("rpc.request.metadata.:scheme", "https")
+			}
+		}
 
 		reqBody, err := marshalMessageableJSON(req)
 		if dataCaptureConfig.RpcBody.Request.Value &&

--- a/sdk/instrumentation/google.golang.org/grpc/server.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server.go
@@ -240,11 +240,14 @@ func WrapStatsHandler(delegate stats.Handler, spanFromContext sdk.SpanFromContex
 
 func setSchemeAttributes(ctx context.Context, span sdk.Span) {
 	peer, ok := peer.FromContext(ctx)
-	if ok {
-		if peer.AuthInfo != nil {
-			span.SetAttribute("rpc.request.metadata.:scheme", "https")
-		} else {
-			span.SetAttribute("rpc.request.metadata.:scheme", "http")
-		}
+	if !ok {
+		return
 	}
+	scheme := "http"
+	// https://github.com/grpc/grpc-go/blob/ebfe3be62a82434bc83fd7b36410141a603a96be/peer/peer.go#L35-L36
+	if peer.AuthInfo != nil {
+		scheme = "https"
+	}
+
+	span.SetAttribute("rpc.request.metadata.:scheme", scheme)
 }

--- a/sdk/instrumentation/google.golang.org/grpc/server.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server.go
@@ -87,14 +87,7 @@ func wrapHandler(
 
 		span.SetAttribute("rpc.request.metadata.:method", "POST")
 
-		peer, ok := peer.FromContext(ctx)
-		if ok {
-			if peer.AuthInfo == nil {
-				span.SetAttribute("rpc.request.metadata.:scheme", "http")
-			} else {
-				span.SetAttribute("rpc.request.metadata.:scheme", "https")
-			}
-		}
+		setSchemeAttributes(ctx, span)
 
 		reqBody, err := marshalMessageableJSON(req)
 		if dataCaptureConfig.RpcBody.Request.Value &&
@@ -241,5 +234,16 @@ func WrapStatsHandler(delegate stats.Handler, spanFromContext sdk.SpanFromContex
 		spanFromContext:   spanFromContext,
 		defaultAttributes: defaultAttributes,
 		dataCaptureConfig: internalconfig.GetConfig().GetDataCapture(),
+	}
+}
+
+func setSchemeAttributes(ctx context.Context, span sdk.Span) {
+	peer, ok := peer.FromContext(ctx)
+	if ok {
+		if peer.AuthInfo != nil {
+			span.SetAttribute("rpc.request.metadata.:scheme", "https")
+		} else {
+			span.SetAttribute("rpc.request.metadata.:scheme", "http")
+		}
 	}
 }

--- a/sdk/instrumentation/google.golang.org/grpc/server.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"net/http"
 	"strings"
 
 	"github.com/hypertrace/goagent/config"
@@ -85,7 +86,7 @@ func wrapHandler(
 		span.SetAttribute("rpc.service", pieces[0])
 		span.SetAttribute("rpc.method", pieces[1])
 
-		span.SetAttribute("rpc.request.metadata.:method", "POST")
+		span.SetAttribute("rpc.request.metadata.:method", http.MethodPost)
 
 		setSchemeAttributes(ctx, span)
 

--- a/sdk/instrumentation/google.golang.org/grpc/server_test.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
 
@@ -40,6 +42,7 @@ func TestServerInterceptorHelloWorldSuccess(t *testing.T) {
 	dialer := createDialer(s)
 
 	ctx := context.Background()
+
 	conn, err := grpc.DialContext(
 		ctx,
 		"bufnet",
@@ -228,4 +231,44 @@ func TestServerHandlerHelloWorldSuccess(t *testing.T) {
 
 	_ = span.ReadAttribute("container_id") // needed in containarized envs
 	assert.Zero(t, span.RemainingAttributes(), "unexpected remaining attribute: %v", span.Attributes)
+}
+
+type fakeALTSAuthInfo struct {
+	peerServiceAccount string
+}
+
+func (f fakeALTSAuthInfo) AuthType() string {
+	return "tls"
+}
+
+func TestSetSchemeAttributes(t *testing.T) {
+	tCases := map[string]struct {
+		expectedScheme string
+		AuthInfo       credentials.AuthInfo
+	}{
+		"no auth info": {
+			expectedScheme: "http",
+			AuthInfo:        nil,
+		},
+		"with auth info": {
+			expectedScheme: "https",
+			AuthInfo: fakeALTSAuthInfo{},
+		},
+	}
+
+	for name, tCase := range tCases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			ms := mock.NewSpan()
+
+			p := &peer.Peer{
+				Addr:     nil,
+				AuthInfo: tCase.AuthInfo,
+			}
+
+			pctx := peer.NewContext(ctx, p)
+			setSchemeAttributes(pctx, ms)
+			assert.Equal(t, tCase.expectedScheme, ms.ReadAttribute("rpc.request.metadata.:scheme"))
+		})
+	}
 }

--- a/sdk/instrumentation/google.golang.org/grpc/server_test.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server_test.go
@@ -234,7 +234,6 @@ func TestServerHandlerHelloWorldSuccess(t *testing.T) {
 }
 
 type fakeALTSAuthInfo struct {
-	peerServiceAccount string
 }
 
 func (f fakeALTSAuthInfo) AuthType() string {
@@ -248,11 +247,11 @@ func TestSetSchemeAttributes(t *testing.T) {
 	}{
 		"no auth info": {
 			expectedScheme: "http",
-			AuthInfo:        nil,
+			AuthInfo:       nil,
 		},
 		"with auth info": {
 			expectedScheme: "https",
-			AuthInfo: fakeALTSAuthInfo{},
+			AuthInfo:       fakeALTSAuthInfo{},
 		},
 	}
 

--- a/sdk/instrumentation/google.golang.org/grpc/server_test.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server_test.go
@@ -69,6 +69,7 @@ func TestServerInterceptorHelloWorldSuccess(t *testing.T) {
 	assert.Equal(t, "helloworld.Greeter", span.ReadAttribute("rpc.service").(string))
 	assert.Equal(t, "SayHello", span.ReadAttribute("rpc.method").(string))
 	assert.Equal(t, "test_value", span.ReadAttribute("rpc.request.metadata.test_key").(string))
+	assert.Equal(t, "POST", span.ReadAttribute("rpc.request.metadata.:method").(string))
 
 	expectedBody := "{\"name\":\"Pupo\"}"
 	actualBody := span.ReadAttribute("rpc.request.body").(string)


### PR DESCRIPTION
:method & :scheme are not reported - these fields are not present in the `metadata.FromIncomingContext(ctx)` metadata map.

## Description
method - grpc will error if a request is received that doesn't use POST, and the grpc spec defines post as the only valid http method, just apply a default for this attribute
scheme - peer.AuthInfo will be nil if no transport security is configured


### Testing
Edits to existing/new test cases for these attributes

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

