### PR TITLE
Report v1 proto data

### DIFF
--- a/instrumentation/hypertrace/google.golang.org/hypergrpc/examples/helloworld/helloworldv1.pb.go
+++ b/instrumentation/hypertrace/google.golang.org/hypergrpc/examples/helloworld/helloworldv1.pb.go
@@ -1,0 +1,52 @@
+package helloworld
+
+import proto "github.com/golang/protobuf/proto"
+import fmt "fmt"
+import math "math"
+
+// Reference imports to suppress errors if they are not otherwise used.
+var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
+
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+// A compilation error at this line likely means your copy of the
+// proto package needs to be updated.
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+
+type HelloResponse struct {
+	Name            string   `protobuf:"bytes,1,opt,name=name,json=name,proto3" json:"product_id,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *HelloResponse) Reset()         { *m = HelloResponse{} }
+func (m *HelloResponse) String() string { return proto.CompactTextString(m) }
+func (*HelloResponse) ProtoMessage()    {}
+
+func (m *HelloResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CartItem.Unmarshal(m, b)
+}
+func (m *HelloResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CartItem.Marshal(b, m, deterministic)
+}
+func (dst *HelloResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CartItem.Merge(dst, src)
+}
+func (m *HelloResponse) XXX_Size() int {
+	return xxx_messageInfo_CartItem.Size(m)
+}
+func (m *HelloResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_CartItem.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_CartItem proto.InternalMessageInfo
+
+func (m *HelloResponse) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}

--- a/sdk/instrumentation/google.golang.org/grpc/serializer.go
+++ b/sdk/instrumentation/google.golang.org/grpc/serializer.go
@@ -1,18 +1,18 @@
 package grpc
 
 import (
+	"github.com/golang/protobuf/proto"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 )
 
-// We need a marshaller that does not omit the zero (e.g. 0 or false) to not to lose pontetially
-// intesting information.
+// We need a marshaller that does not omit the zero (e.g. 0 or false) to not to lose potentially
+// interesting information.
 var marshaler = protojson.MarshalOptions{EmitUnpopulated: false}
 
 // MarshalMessageableJSON marshals a value that an be cast as proto.Message into JSON.
 func marshalMessageableJSON(messageable interface{}) ([]byte, error) {
-	if m, ok := messageable.(proto.Message); ok {
-		return marshaler.Marshal(m)
+	if msg, ok := messageable.(proto.Message); ok {
+		return marshaler.Marshal(proto.MessageV2(msg))
 	}
 
 	return nil, nil

--- a/sdk/instrumentation/google.golang.org/grpc/serializer_test.go
+++ b/sdk/instrumentation/google.golang.org/grpc/serializer_test.go
@@ -1,0 +1,22 @@
+package grpc
+
+import (
+	"testing"
+
+	pb "github.com/hypertrace/goagent/instrumentation/hypertrace/google.golang.org/hypergrpc/examples/helloworld"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithProtobufMessageFormatV2(t *testing.T){
+	msg := &pb.HelloReply{Message: "Test Message"}
+	data, err := marshalMessageableJSON(msg)
+	assert.Nil(t, err)
+	assert.Equal(t, "{\"message\":\"Test Message\"}", string(data[:]))
+}
+
+func TestWithProtobufMessageFormatV1(t *testing.T){
+	msg := &pb.HelloResponse{Name: "Test Name"}
+	data, err := marshalMessageableJSON(msg)
+	assert.Nil(t, err)
+	assert.Equal(t, "{\"name\":\"Test Name\"}", string(data[:]))
+}

--- a/sdk/instrumentation/google.golang.org/grpc/serializer_test.go
+++ b/sdk/instrumentation/google.golang.org/grpc/serializer_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWithProtobufMessageFormatV2(t *testing.T){
+func TestWithProtobufMessageFormatV2(t *testing.T) {
 	msg := &pb.HelloReply{Message: "Test Message"}
 	data, err := marshalMessageableJSON(msg)
 	assert.Nil(t, err)
 	assert.Equal(t, "{\"message\":\"Test Message\"}", string(data[:]))
 }
 
-func TestWithProtobufMessageFormatV1(t *testing.T){
+func TestWithProtobufMessageFormatV1(t *testing.T) {
 	msg := &pb.HelloResponse{Name: "Test Name"}
 	data, err := marshalMessageableJSON(msg)
 	assert.Nil(t, err)


### PR DESCRIPTION
## Description
Applications that use an older protobuf format previously would not have their body captured. 

We need to use the `github.com/golang/protobuf/proto` proto instead because the conversion methods(`MessageV2`) are not available in the `google.golang.org/protobuf/proto`



### Testing
New test asserts we can capture v1 & v2 protobuf spans(v2 is what was previously present in the hello world sample app)

Ensured the sample app still reports body data, and tested a v1 protobuf application locally and it is now reporting that data.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

