### PR TITLE
chore: relocate internal package used for testing.

### DIFF
--- a/instrumentation/opentelemetry/database/hypersql/sql_test.go
+++ b/instrumentation/opentelemetry/database/hypersql/sql_test.go
@@ -7,7 +7,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/hypertrace/goagent/instrumentation/opentelemetry/internal"
+	"github.com/hypertrace/goagent/instrumentation/opentelemetry/internal/tracetesting"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -15,7 +15,7 @@ import (
 )
 
 func createDB(t *testing.T) (*sql.DB, func() []sdktrace.ReadOnlySpan) {
-	_, flusher := internal.InitTracer()
+	_, flusher := tracetesting.InitTracer()
 
 	driverName, err := Register("sqlite3")
 	if err != nil {
@@ -56,7 +56,7 @@ func TestQuerySuccess(t *testing.T) {
 	assert.Equal(t, "db:query", span.Name())
 	assert.Equal(t, apitrace.SpanKindClient, span.SpanKind())
 
-	attrs := internal.LookupAttributes(span.Attributes())
+	attrs := tracetesting.LookupAttributes(span.Attributes())
 	assert.Equal(t, "SELECT 1 WHERE 1 = ?", attrs.Get("db.statement").AsString())
 	assert.Equal(t, "sqlite", attrs.Get("db.system").AsString())
 	assert.False(t, attrs.Has("error"))
@@ -87,7 +87,7 @@ func TestExecSuccess(t *testing.T) {
 	assert.Equal(t, "db:exec", span.Name())
 	assert.Equal(t, apitrace.SpanKindClient, span.SpanKind())
 
-	attrs := internal.LookupAttributes(span.Attributes())
+	attrs := tracetesting.LookupAttributes(span.Attributes())
 	assert.False(t, attrs.Has("error"))
 
 	db.Close()
@@ -135,7 +135,7 @@ func TestTxWithCommitSuccess(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		assert.Equal(t, apitrace.SpanKindClient, spans[i].SpanKind())
-		attrs := internal.LookupAttributes(spans[i].Attributes())
+		attrs := tracetesting.LookupAttributes(spans[i].Attributes())
 		assert.False(t, attrs.Has("error"))
 	}
 
@@ -181,7 +181,7 @@ func TestTxWithRollbackSuccess(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		assert.Equal(t, apitrace.SpanKindClient, spans[i].SpanKind())
-		attrs := internal.LookupAttributes(spans[i].Attributes())
+		attrs := tracetesting.LookupAttributes(spans[i].Attributes())
 		assert.False(t, attrs.Has("error"))
 	}
 

--- a/instrumentation/opentelemetry/github.com/gorilla/hypermux/mux_test.go
+++ b/instrumentation/opentelemetry/github.com/gorilla/hypermux/mux_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
-	"github.com/hypertrace/goagent/instrumentation/opentelemetry/internal"
+	"github.com/hypertrace/goagent/instrumentation/opentelemetry/internal/tracetesting"
 	sdkhttp "github.com/hypertrace/goagent/sdk/instrumentation/net/http"
 	"go.opentelemetry.io/otel/trace"
 	"gotest.tools/assert"
@@ -30,7 +30,7 @@ func findAvailablePort() (int, error) {
 }
 
 func TestSpanRecordedCorrectly(t *testing.T) {
-	_, flusher := internal.InitTracer()
+	_, flusher := tracetesting.InitTracer()
 
 	r := mux.NewRouter()
 	r.HandleFunc("/things/{thing_id}", func(rw http.ResponseWriter, r *http.Request) {
@@ -76,7 +76,7 @@ func TestSpanRecordedCorrectly(t *testing.T) {
 	assert.Equal(t, "/things/{thing_id}", span.Name())
 	assert.Equal(t, span.SpanKind(), trace.SpanKindServer)
 
-	attrs := internal.LookupAttributes(span.Attributes())
+	attrs := tracetesting.LookupAttributes(span.Attributes())
 	assert.Equal(t, "POST", attrs.Get("http.method").AsString())
 	assert.Equal(t, "abc123xyz", attrs.Get("http.request.header.api_key").AsString())
 	assert.Equal(t, `{"name":"Jacinto"}`, attrs.Get("http.request.body").AsString())

--- a/instrumentation/opentelemetry/github.com/jackc/hyperpgx/integrationtest/integration_test.go
+++ b/instrumentation/opentelemetry/github.com/jackc/hyperpgx/integrationtest/integration_test.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/hypertrace/goagent/instrumentation/opentelemetry/github.com/jackc/hyperpgx"
+	"github.com/hypertrace/goagent/instrumentation/opentelemetry/internal/tracetesting"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/hypertrace/goagent/instrumentation/opentelemetry/internal"
 	apitrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -24,7 +24,7 @@ func TestQuerySuccess(t *testing.T) {
 	}
 	defer conn.Close(context.Background())
 
-	_, flusher := internal.InitTracer()
+	_, flusher := tracetesting.InitTracer()
 
 	select {
 	// We timeout after 5 secs of trying ping the DB.
@@ -54,7 +54,7 @@ func TestQuerySuccess(t *testing.T) {
 	assert.Equal(t, "db:query", span.Name())
 	assert.Equal(t, apitrace.SpanKindClient, span.SpanKind())
 
-	attrs := internal.LookupAttributes(span.Attributes())
+	attrs := tracetesting.LookupAttributes(span.Attributes())
 	assert.Equal(t, "SELECT 1 WHERE 1 = $1", attrs.Get("db.statement").AsString())
 	assert.Equal(t, "postgres", attrs.Get("db.system").AsString())
 	assert.Equal(t, "root", attrs.Get("db.user").AsString())

--- a/instrumentation/opentelemetry/google.golang.org/hypergrpc/client_test.go
+++ b/instrumentation/opentelemetry/google.golang.org/hypergrpc/client_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hypertrace/goagent/instrumentation/opentelemetry/google.golang.org/hypergrpc/examples/helloworld"
-	"github.com/hypertrace/goagent/instrumentation/opentelemetry/internal"
+	"github.com/hypertrace/goagent/instrumentation/opentelemetry/internal/tracetesting"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	otelcodes "go.opentelemetry.io/otel/codes"
@@ -16,7 +16,7 @@ import (
 )
 
 func TestClientHelloWorldSuccess(t *testing.T) {
-	_, flusher := internal.InitTracer()
+	_, flusher := tracetesting.InitTracer()
 
 	s := grpc.NewServer()
 	defer s.Stop()
@@ -65,7 +65,7 @@ func TestClientHelloWorldSuccess(t *testing.T) {
 	span := spans[0]
 	assert.Equal(t, "helloworld.Greeter/SayHello", span.Name())
 
-	attrs := internal.LookupAttributes(span.Attributes())
+	attrs := tracetesting.LookupAttributes(span.Attributes())
 	assert.Equal(t, "grpc", attrs.Get("rpc.system").AsString())
 	assert.Equal(t, "helloworld.Greeter", attrs.Get("rpc.service").AsString())
 	assert.Equal(t, "SayHello", attrs.Get("rpc.method").AsString())
@@ -91,7 +91,7 @@ func TestClientHelloWorldSuccess(t *testing.T) {
 }
 
 func TestClientRegisterPersonFails(t *testing.T) {
-	_, flusher := internal.InitTracer()
+	_, flusher := tracetesting.InitTracer()
 
 	s := grpc.NewServer()
 	defer s.Stop()
@@ -138,7 +138,7 @@ func TestClientRegisterPersonFails(t *testing.T) {
 }
 
 func BenchmarkClientRequestResponseBodyMarshaling(b *testing.B) {
-	internal.InitTracer()
+	tracetesting.InitTracer()
 
 	s := grpc.NewServer()
 	defer s.Stop()
@@ -181,7 +181,7 @@ func BenchmarkClientRequestResponseBodyMarshaling(b *testing.B) {
 }
 
 func BenchmarkClientRequestDefaultInterceptor(b *testing.B) {
-	internal.InitTracer()
+	tracetesting.InitTracer()
 
 	s := grpc.NewServer()
 	defer s.Stop()

--- a/instrumentation/opentelemetry/google.golang.org/hypergrpc/server_test.go
+++ b/instrumentation/opentelemetry/google.golang.org/hypergrpc/server_test.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	"log"
 	"net"
-	reflect "reflect"
+	"reflect"
 	"testing"
 
 	"github.com/hypertrace/goagent/instrumentation/opentelemetry/google.golang.org/hypergrpc/examples/helloworld"
-	"github.com/hypertrace/goagent/instrumentation/opentelemetry/internal"
+	"github.com/hypertrace/goagent/instrumentation/opentelemetry/internal/tracetesting"
 	sdkgrpc "github.com/hypertrace/goagent/sdk/instrumentation/google.golang.org/grpc"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -79,7 +79,7 @@ func jsonEqual(a, b string) (bool, error) {
 }
 
 func TestServerRegisterPersonSuccess(t *testing.T) {
-	_, flusher := internal.InitTracer()
+	_, flusher := tracetesting.InitTracer()
 
 	s := grpc.NewServer(
 		grpc.UnaryInterceptor(
@@ -122,7 +122,7 @@ func TestServerRegisterPersonSuccess(t *testing.T) {
 	span := spans[0]
 	assert.Equal(t, "helloworld.Greeter/SayHello", span.Name())
 
-	attrs := internal.LookupAttributes(span.Attributes())
+	attrs := tracetesting.LookupAttributes(span.Attributes())
 	assert.Equal(t, "grpc", attrs.Get("rpc.system").AsString())
 	assert.Equal(t, "helloworld.Greeter", attrs.Get("rpc.service").AsString())
 	assert.Equal(t, "SayHello", attrs.Get("rpc.method").AsString())
@@ -146,7 +146,7 @@ func TestServerRegisterPersonSuccess(t *testing.T) {
 }
 
 func TestServerRegisterPersonFails(t *testing.T) {
-	_, flusher := internal.InitTracer()
+	_, flusher := tracetesting.InitTracer()
 
 	s := grpc.NewServer(
 		grpc.UnaryInterceptor(
@@ -192,7 +192,7 @@ func TestServerRegisterPersonFails(t *testing.T) {
 }
 
 func BenchmarkServerRequestResponseBodyMarshaling(b *testing.B) {
-	internal.InitTracer()
+	tracetesting.InitTracer()
 
 	s := grpc.NewServer(
 		grpc.UnaryInterceptor(
@@ -234,7 +234,7 @@ func BenchmarkServerRequestResponseBodyMarshaling(b *testing.B) {
 }
 
 func BenchmarkServerRequestDefaultInterceptor(b *testing.B) {
-	internal.InitTracer()
+	tracetesting.InitTracer()
 
 	s := grpc.NewServer(
 		grpc.UnaryInterceptor(otelgrpc.UnaryServerInterceptor()),

--- a/instrumentation/opentelemetry/internal/tracetesting/recorder.go
+++ b/instrumentation/opentelemetry/internal/tracetesting/recorder.go
@@ -1,4 +1,4 @@
-package internal
+package tracetesting
 
 import (
 	"context"
@@ -6,27 +6,27 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
-var _ trace.SpanExporter = &Recorder{}
+var _ trace.SpanExporter = &recorder{}
 
-// Recorder records spans being synced through the SpanSyncer interface.
-type Recorder struct {
+// recorder records spans being synced through the SpanSyncer interface.
+type recorder struct {
 	spans []trace.ReadOnlySpan
 }
 
 // ExportSpans records spans into the internal buffer
-func (r *Recorder) ExportSpans(ctx context.Context, s []trace.ReadOnlySpan) error {
+func (r *recorder) ExportSpans(_ context.Context, s []trace.ReadOnlySpan) error {
 	r.spans = append(r.spans, s...)
 	return nil
 }
 
 // Shutdown flushes the buffer
-func (r *Recorder) Shutdown(_ context.Context) error {
+func (r *recorder) Shutdown(_ context.Context) error {
 	_ = r.Flush()
 	return nil
 }
 
 // Flush returns the current recorded spans and reset the recordings
-func (r *Recorder) Flush() []trace.ReadOnlySpan {
+func (r *recorder) Flush() []trace.ReadOnlySpan {
 	spans := r.spans
 	r.spans = nil
 	return spans

--- a/instrumentation/opentelemetry/internal/tracetesting/spanattributes.go
+++ b/instrumentation/opentelemetry/internal/tracetesting/spanattributes.go
@@ -1,4 +1,4 @@
-package internal
+package tracetesting
 
 import (
 	"go.opentelemetry.io/otel/attribute"

--- a/instrumentation/opentelemetry/internal/tracetesting/spanattributes_test.go
+++ b/instrumentation/opentelemetry/internal/tracetesting/spanattributes_test.go
@@ -1,4 +1,4 @@
-package internal
+package tracetesting
 
 import (
 	"testing"

--- a/instrumentation/opentelemetry/internal/tracetesting/tracing.go
+++ b/instrumentation/opentelemetry/internal/tracetesting/tracing.go
@@ -1,4 +1,4 @@
-package internal
+package tracetesting
 
 import (
 	"context"
@@ -16,7 +16,7 @@ import (
 // spans for further inspection. Its main purpose is to declare a tracer
 // for TESTING.
 func InitTracer() (apitrace.Tracer, func() []sdktrace.ReadOnlySpan) {
-	exporter := &Recorder{}
+	exporter := &recorder{}
 
 	resources, _ := resource.New(context.Background(), resource.WithAttributes(semconv.ServiceNameKey.String("TestService")))
 


### PR DESCRIPTION
## Description

This PR changes the internal package containing testing utils for tracing into a tracetesting package. This to make it explicit the testing purposes but also to organize the packages under internal.
