### PR TITLE
chore: moves SDK metadata into an internal package.

### DIFF
--- a/instrumentation/opentelemetry/init.go
+++ b/instrumentation/opentelemetry/init.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/hypertrace/goagent/config"
 	sdkconfig "github.com/hypertrace/goagent/sdk/config"
-	"github.com/hypertrace/goagent/version"
 	"go.opentelemetry.io/contrib/propagators/b3"
 	"go.opentelemetry.io/otel"
 	otlpgrpc "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 
+	"github.com/hypertrace/goagent/instrumentation/opentelemetry/internal/metadata"
 	"go.opentelemetry.io/otel/exporters/zipkin"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -158,8 +158,8 @@ func Init(cfg *config.AgentConfig) func() {
 func createResources(serviceName string, resources map[string]string) []attribute.KeyValue {
 	retValues := []attribute.KeyValue{
 		semconv.ServiceNameKey.String(serviceName),
-		semconv.TelemetrySDKNameKey.String("hypertrace"),
-		semconv.TelemetrySDKVersionKey.String(version.Version),
+		semconv.TelemetrySDKNameKey.String(metadata.SDKName),
+		semconv.TelemetrySDKVersionKey.String(metadata.SDKVersion),
 		semconv.TelemetrySDKLanguageGo,
 	}
 

--- a/instrumentation/opentelemetry/internal/metadata/sdk.go
+++ b/instrumentation/opentelemetry/internal/metadata/sdk.go
@@ -1,0 +1,8 @@
+package metadata
+
+import "github.com/hypertrace/goagent/version"
+
+var (
+	SDKName    = "hypertrace"
+	SDKVersion = version.Version
+)


### PR DESCRIPTION
## Description
This PR makes it explicit the metadata for the tracer in opentelemetry's implementation.