### PR TITLE
chore: removes service name as parameter for exporter

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ["1.13", "1.14", "1.15"]
+        go: ["1.13", "1.14", "1.15", "1.16"]
     steps:
       # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
       - name: Check out code


### PR DESCRIPTION
It was required for zipkin exporter but not anymore, see https://github.com/open-telemetry/opentelemetry-go/pull/1697.