### PR TITLE
chore: span kind keeps consistency with status codes.

### DIFF
--- a/instrumentation/opencensus/span.go
+++ b/instrumentation/opencensus/span.go
@@ -66,9 +66,9 @@ func StartSpan(ctx context.Context, name string, opts *sdk.SpanOptions) (context
 
 func mapSpanKind(kind sdk.SpanKind) int {
 	switch kind {
-	case sdk.Client:
+	case sdk.SpanKindClient:
 		return trace.SpanKindClient
-	case sdk.Server:
+	case sdk.SpanKindServer:
 		return trace.SpanKindServer
 	default:
 		return trace.SpanKindUnspecified

--- a/instrumentation/opencensus/span_test.go
+++ b/instrumentation/opencensus/span_test.go
@@ -22,8 +22,8 @@ func TestIsNoop(t *testing.T) {
 }
 
 func TestMapSpanKind(t *testing.T) {
-	assert.Equal(t, mapSpanKind(sdk.Client), trace.SpanKindClient)
-	assert.Equal(t, mapSpanKind(sdk.Server), trace.SpanKindServer)
+	assert.Equal(t, mapSpanKind(sdk.SpanKindClient), trace.SpanKindClient)
+	assert.Equal(t, mapSpanKind(sdk.SpanKindServer), trace.SpanKindServer)
 }
 
 func TestGenerateAttributeSuccess(t *testing.T) {

--- a/instrumentation/opentelemetry/github.com/jackc/hyperpgx/pgx.go
+++ b/instrumentation/opentelemetry/github.com/jackc/hyperpgx/pgx.go
@@ -58,7 +58,7 @@ func (r *wrappedRow) Scan(dest ...interface{}) error {
 }
 
 func (w *wrappedConn) Query(ctx context.Context, query string, optionsAndArgs ...interface{}) (pgx.Rows, error) {
-	ctx, span, closer := opentelemetry.StartSpan(ctx, "db:query", &sdk.SpanOptions{Kind: sdk.Client})
+	ctx, span, closer := opentelemetry.StartSpan(ctx, "db:query", &sdk.SpanOptions{Kind: sdk.SpanKindClient})
 	defer closer()
 
 	for k, v := range w.connAttrs {
@@ -75,7 +75,7 @@ func (w *wrappedConn) Query(ctx context.Context, query string, optionsAndArgs ..
 }
 
 func (w *wrappedConn) QueryRow(ctx context.Context, sql string, optionsAndArgs ...interface{}) pgx.Row {
-	ctx, span, closer := opentelemetry.StartSpan(ctx, "db:query", &sdk.SpanOptions{Kind: sdk.Client})
+	ctx, span, closer := opentelemetry.StartSpan(ctx, "db:query", &sdk.SpanOptions{Kind: sdk.SpanKindClient})
 	defer closer()
 
 	for k, v := range w.connAttrs {
@@ -87,7 +87,7 @@ func (w *wrappedConn) QueryRow(ctx context.Context, sql string, optionsAndArgs .
 }
 
 func (w *wrappedConn) Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error) {
-	ctx, span, closer := opentelemetry.StartSpan(ctx, "exec", &sdk.SpanOptions{Kind: sdk.Client})
+	ctx, span, closer := opentelemetry.StartSpan(ctx, "exec", &sdk.SpanOptions{Kind: sdk.SpanKindClient})
 	defer closer()
 
 	for k, v := range w.connAttrs {
@@ -108,7 +108,7 @@ func (w *wrappedConn) Ping(ctx context.Context) error {
 }
 
 func (w *wrappedConn) QueryFunc(ctx context.Context, sql string, args []interface{}, scans []interface{}, f func(pgx.QueryFuncRow) error) (pgconn.CommandTag, error) {
-	ctx, span, closer := opentelemetry.StartSpan(ctx, "exec", &sdk.SpanOptions{Kind: sdk.Client})
+	ctx, span, closer := opentelemetry.StartSpan(ctx, "exec", &sdk.SpanOptions{Kind: sdk.SpanKindClient})
 	defer closer()
 
 	for k, v := range w.connAttrs {

--- a/instrumentation/opentelemetry/span.go
+++ b/instrumentation/opentelemetry/span.go
@@ -62,13 +62,13 @@ var StartSpan = startSpan(otel.GetTracerProvider)
 
 func mapSpanKind(kind sdk.SpanKind) trace.SpanKind {
 	switch kind {
-	case sdk.Client:
+	case sdk.SpanKindClient:
 		return trace.SpanKindClient
-	case sdk.Server:
+	case sdk.SpanKindServer:
 		return trace.SpanKindServer
-	case sdk.Producer:
+	case sdk.SpanKindProducer:
 		return trace.SpanKindProducer
-	case sdk.Consumer:
+	case sdk.SpanKindConsumer:
 		return trace.SpanKindConsumer
 	default:
 		return trace.SpanKindUnspecified

--- a/instrumentation/opentelemetry/span_test.go
+++ b/instrumentation/opentelemetry/span_test.go
@@ -28,10 +28,10 @@ func TestIsNoop(t *testing.T) {
 }
 
 func TestMapSpanKind(t *testing.T) {
-	assert.Equal(t, trace.SpanKindClient, mapSpanKind(sdk.Client))
-	assert.Equal(t, trace.SpanKindServer, mapSpanKind(sdk.Server))
-	assert.Equal(t, trace.SpanKindProducer, mapSpanKind(sdk.Producer))
-	assert.Equal(t, trace.SpanKindConsumer, mapSpanKind(sdk.Consumer))
+	assert.Equal(t, trace.SpanKindClient, mapSpanKind(sdk.SpanKindClient))
+	assert.Equal(t, trace.SpanKindServer, mapSpanKind(sdk.SpanKindServer))
+	assert.Equal(t, trace.SpanKindProducer, mapSpanKind(sdk.SpanKindProducer))
+	assert.Equal(t, trace.SpanKindConsumer, mapSpanKind(sdk.SpanKindConsumer))
 }
 
 func TestSetAttributeSuccess(t *testing.T) {

--- a/sdk/instrumentation/database/sql/sql.go
+++ b/sdk/instrumentation/database/sql/sql.go
@@ -22,7 +22,7 @@ type interceptor struct {
 }
 
 func (in *interceptor) StmtQueryContext(ctx context.Context, conn driver.StmtQueryContext, query string, args []driver.NamedValue) (driver.Rows, error) {
-	ctx, span, end := in.startSpan(ctx, "db:query", &sdk.SpanOptions{Kind: sdk.Client})
+	ctx, span, end := in.startSpan(ctx, "db:query", &sdk.SpanOptions{Kind: sdk.SpanKindClient})
 	defer end()
 
 	for key, value := range in.defaultAttributes {
@@ -39,7 +39,7 @@ func (in *interceptor) StmtQueryContext(ctx context.Context, conn driver.StmtQue
 }
 
 func (in *interceptor) StmtExecContext(ctx context.Context, conn driver.StmtExecContext, query string, args []driver.NamedValue) (driver.Result, error) {
-	ctx, span, end := in.startSpan(ctx, "db:exec", &sdk.SpanOptions{Kind: sdk.Client})
+	ctx, span, end := in.startSpan(ctx, "db:exec", &sdk.SpanOptions{Kind: sdk.SpanKindClient})
 	defer end()
 
 	for key, value := range in.defaultAttributes {
@@ -56,7 +56,7 @@ func (in *interceptor) StmtExecContext(ctx context.Context, conn driver.StmtExec
 }
 
 func (in *interceptor) ConnQueryContext(ctx context.Context, conn driver.QueryerContext, query string, args []driver.NamedValue) (driver.Rows, error) {
-	ctx, span, end := in.startSpan(ctx, "db:query", &sdk.SpanOptions{Kind: sdk.Client})
+	ctx, span, end := in.startSpan(ctx, "db:query", &sdk.SpanOptions{Kind: sdk.SpanKindClient})
 	defer end()
 
 	for key, value := range in.defaultAttributes {
@@ -73,7 +73,7 @@ func (in *interceptor) ConnQueryContext(ctx context.Context, conn driver.Queryer
 }
 
 func (in *interceptor) ConnExecContext(ctx context.Context, conn driver.ExecerContext, query string, args []driver.NamedValue) (driver.Result, error) {
-	ctx, span, end := in.startSpan(ctx, "db:exec", &sdk.SpanOptions{Kind: sdk.Client})
+	ctx, span, end := in.startSpan(ctx, "db:exec", &sdk.SpanOptions{Kind: sdk.SpanKindClient})
 	defer end()
 
 	for key, value := range in.defaultAttributes {
@@ -90,7 +90,7 @@ func (in *interceptor) ConnExecContext(ctx context.Context, conn driver.ExecerCo
 }
 
 func (in *interceptor) ConnBeginTx(ctx context.Context, conn driver.ConnBeginTx, txOpts driver.TxOptions) (driver.Tx, error) {
-	ctx, span, end := in.startSpan(ctx, "db:begin_transaction", &sdk.SpanOptions{Kind: sdk.Client})
+	ctx, span, end := in.startSpan(ctx, "db:begin_transaction", &sdk.SpanOptions{Kind: sdk.SpanKindClient})
 	defer end()
 
 	for key, value := range in.defaultAttributes {
@@ -106,7 +106,7 @@ func (in *interceptor) ConnBeginTx(ctx context.Context, conn driver.ConnBeginTx,
 }
 
 func (in *interceptor) ConnPrepareContext(ctx context.Context, conn driver.ConnPrepareContext, query string) (driver.Stmt, error) {
-	ctx, span, end := in.startSpan(ctx, "db:prepare", &sdk.SpanOptions{Kind: sdk.Client})
+	ctx, span, end := in.startSpan(ctx, "db:prepare", &sdk.SpanOptions{Kind: sdk.SpanKindClient})
 	defer end()
 
 	for key, value := range in.defaultAttributes {
@@ -122,7 +122,7 @@ func (in *interceptor) ConnPrepareContext(ctx context.Context, conn driver.ConnP
 }
 
 func (in *interceptor) TxCommit(ctx context.Context, tx driver.Tx) error {
-	_, span, end := in.startSpan(ctx, "db:commit", &sdk.SpanOptions{Kind: sdk.Client})
+	_, span, end := in.startSpan(ctx, "db:commit", &sdk.SpanOptions{Kind: sdk.SpanKindClient})
 	defer end()
 
 	for key, value := range in.defaultAttributes {
@@ -138,7 +138,7 @@ func (in *interceptor) TxCommit(ctx context.Context, tx driver.Tx) error {
 }
 
 func (in *interceptor) TxRollback(ctx context.Context, tx driver.Tx) error {
-	_, span, end := in.startSpan(ctx, "db:rollback", &sdk.SpanOptions{Kind: sdk.Client})
+	_, span, end := in.startSpan(ctx, "db:rollback", &sdk.SpanOptions{Kind: sdk.SpanKindClient})
 	defer end()
 
 	for key, value := range in.defaultAttributes {

--- a/sdk/instrumentation/database/sql/sql_test.go
+++ b/sdk/instrumentation/database/sql/sql_test.go
@@ -65,7 +65,7 @@ func TestQuerySuccess(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal(t, "db:query", span.Name)
-	assert.Equal(t, sdk.Client, span.Options.Kind)
+	assert.Equal(t, sdk.SpanKindClient, span.Options.Kind)
 
 	assert.Equal(t, "SELECT 1 WHERE 1 = ?", span.ReadAttribute("db.statement").(string))
 	assert.Equal(t, "sqlite", span.ReadAttribute("db.system").(string))
@@ -95,7 +95,7 @@ func TestExecSuccess(t *testing.T) {
 	assert.Equal(t, 1, len(spans))
 
 	span := spans[0]
-	assert.Equal(t, sdk.Client, span.Options.Kind)
+	assert.Equal(t, sdk.SpanKindClient, span.Options.Kind)
 	assert.Equal(t, "db:exec", span.Name)
 	assert.Nil(t, span.ReadAttribute("error"))
 }
@@ -141,7 +141,7 @@ func TestTxWithCommitSuccess(t *testing.T) {
 	assert.Equal(t, "db:commit", spans[4].Name)
 
 	for i := 0; i < 5; i++ {
-		assert.Equal(t, sdk.Client, spans[i].Options.Kind)
+		assert.Equal(t, sdk.SpanKindClient, spans[i].Options.Kind)
 		assert.Nil(t, spans[i].ReadAttribute("error"))
 	}
 
@@ -186,7 +186,7 @@ func TestTxWithRollbackSuccess(t *testing.T) {
 	assert.Equal(t, "db:rollback", spans[4].Name)
 
 	for i := 0; i < 5; i++ {
-		assert.Equal(t, sdk.Client, spans[i].Options.Kind)
+		assert.Equal(t, sdk.SpanKindClient, spans[i].Options.Kind)
 		assert.Nil(t, spans[i].ReadAttribute("error"))
 	}
 

--- a/sdk/span.go
+++ b/sdk/span.go
@@ -31,11 +31,11 @@ type SpanFromContext func(ctx context.Context) Span
 type SpanKind string
 
 const (
-	Undetermined SpanKind = ""
-	Client       SpanKind = "CLIENT"
-	Server       SpanKind = "SERVER"
-	Producer     SpanKind = "PRODUCER"
-	Consumer     SpanKind = "CONSUMER"
+	SpanKindUndetermined SpanKind = ""
+	SpanKindClient       SpanKind = "CLIENT"
+	SpanKindServer       SpanKind = "SERVER"
+	SpanKindProducer     SpanKind = "PRODUCER"
+	SpanKindConsumer     SpanKind = "CONSUMER"
 )
 
 // SpanOptions describes the options for starting a span


### PR DESCRIPTION
Given https://github.com/hypertrace/goagent/pull/141 we keep consistency for kinds too.