### PR TITLE
chore: adds span status to SQL instrumentation.

### DIFF
--- a/sdk/instrumentation/database/sql/sql.go
+++ b/sdk/instrumentation/database/sql/sql.go
@@ -21,6 +21,15 @@ type interceptor struct {
 	defaultAttributes map[string]string
 }
 
+func setError(s sdk.Span, err error) {
+	if err != nil {
+		s.SetError(err)
+		s.SetStatus(sdk.StatusCodeError, "")
+	} else {
+		s.SetStatus(sdk.StatusCodeOk, "")
+	}
+}
+
 func (in *interceptor) StmtQueryContext(ctx context.Context, conn driver.StmtQueryContext, query string, args []driver.NamedValue) (driver.Rows, error) {
 	ctx, span, end := in.startSpan(ctx, "db:query", &sdk.SpanOptions{Kind: sdk.SpanKindClient})
 	defer end()
@@ -31,11 +40,7 @@ func (in *interceptor) StmtQueryContext(ctx context.Context, conn driver.StmtQue
 	span.SetAttribute("db.statement", query)
 
 	rows, err := conn.QueryContext(ctx, args)
-	if err != nil {
-		span.SetError(err)
-	} else {
-		span.SetStatus(sdk.StatusCodeOk, "")
-	}
+	setError(span, err)
 
 	return rows, err
 }
@@ -50,11 +55,7 @@ func (in *interceptor) StmtExecContext(ctx context.Context, conn driver.StmtExec
 	span.SetAttribute("db.statement", query)
 
 	rows, err := conn.ExecContext(ctx, args)
-	if err != nil {
-		span.SetError(err)
-	} else {
-		span.SetStatus(sdk.StatusCodeOk, "")
-	}
+	setError(span, err)
 
 	return rows, err
 }
@@ -69,11 +70,7 @@ func (in *interceptor) ConnQueryContext(ctx context.Context, conn driver.Queryer
 	span.SetAttribute("db.statement", query)
 
 	rows, err := conn.QueryContext(ctx, query, args)
-	if err != nil {
-		span.SetError(err)
-	} else {
-		span.SetStatus(sdk.StatusCodeOk, "")
-	}
+	setError(span, err)
 
 	return rows, err
 }
@@ -88,11 +85,7 @@ func (in *interceptor) ConnExecContext(ctx context.Context, conn driver.ExecerCo
 	span.SetAttribute("db.statement", query)
 
 	rows, err := conn.ExecContext(ctx, query, args)
-	if err != nil {
-		span.SetError(err)
-	} else {
-		span.SetStatus(sdk.StatusCodeOk, "")
-	}
+	setError(span, err)
 
 	return rows, err
 }
@@ -106,11 +99,7 @@ func (in *interceptor) ConnBeginTx(ctx context.Context, conn driver.ConnBeginTx,
 	}
 
 	tx, err := conn.BeginTx(ctx, txOpts)
-	if err != nil {
-		span.SetError(err)
-	} else {
-		span.SetStatus(sdk.StatusCodeOk, "")
-	}
+	setError(span, err)
 
 	return tx, err
 }
@@ -124,11 +113,7 @@ func (in *interceptor) ConnPrepareContext(ctx context.Context, conn driver.ConnP
 	}
 
 	tx, err := conn.PrepareContext(ctx, query)
-	if err != nil {
-		span.SetError(err)
-	} else {
-		span.SetStatus(sdk.StatusCodeOk, "")
-	}
+	setError(span, err)
 
 	return tx, err
 }
@@ -142,11 +127,7 @@ func (in *interceptor) TxCommit(ctx context.Context, tx driver.Tx) error {
 	}
 
 	err := tx.Commit()
-	if err != nil {
-		span.SetError(err)
-	} else {
-		span.SetStatus(sdk.StatusCodeOk, "")
-	}
+	setError(span, err)
 
 	return err
 }
@@ -160,11 +141,7 @@ func (in *interceptor) TxRollback(ctx context.Context, tx driver.Tx) error {
 	}
 
 	err := tx.Rollback()
-	if err != nil {
-		span.SetError(err)
-	} else {
-		span.SetStatus(sdk.StatusCodeOk, "")
-	}
+	setError(span, err)
 
 	return err
 }

--- a/sdk/instrumentation/database/sql/sql.go
+++ b/sdk/instrumentation/database/sql/sql.go
@@ -33,6 +33,8 @@ func (in *interceptor) StmtQueryContext(ctx context.Context, conn driver.StmtQue
 	rows, err := conn.QueryContext(ctx, args)
 	if err != nil {
 		span.SetError(err)
+	} else {
+		span.SetStatus(sdk.StatusCodeOk, "")
 	}
 
 	return rows, err
@@ -50,6 +52,8 @@ func (in *interceptor) StmtExecContext(ctx context.Context, conn driver.StmtExec
 	rows, err := conn.ExecContext(ctx, args)
 	if err != nil {
 		span.SetError(err)
+	} else {
+		span.SetStatus(sdk.StatusCodeOk, "")
 	}
 
 	return rows, err
@@ -67,6 +71,8 @@ func (in *interceptor) ConnQueryContext(ctx context.Context, conn driver.Queryer
 	rows, err := conn.QueryContext(ctx, query, args)
 	if err != nil {
 		span.SetError(err)
+	} else {
+		span.SetStatus(sdk.StatusCodeOk, "")
 	}
 
 	return rows, err
@@ -84,6 +90,8 @@ func (in *interceptor) ConnExecContext(ctx context.Context, conn driver.ExecerCo
 	rows, err := conn.ExecContext(ctx, query, args)
 	if err != nil {
 		span.SetError(err)
+	} else {
+		span.SetStatus(sdk.StatusCodeOk, "")
 	}
 
 	return rows, err
@@ -100,6 +108,8 @@ func (in *interceptor) ConnBeginTx(ctx context.Context, conn driver.ConnBeginTx,
 	tx, err := conn.BeginTx(ctx, txOpts)
 	if err != nil {
 		span.SetError(err)
+	} else {
+		span.SetStatus(sdk.StatusCodeOk, "")
 	}
 
 	return tx, err
@@ -116,6 +126,8 @@ func (in *interceptor) ConnPrepareContext(ctx context.Context, conn driver.ConnP
 	tx, err := conn.PrepareContext(ctx, query)
 	if err != nil {
 		span.SetError(err)
+	} else {
+		span.SetStatus(sdk.StatusCodeOk, "")
 	}
 
 	return tx, err
@@ -132,6 +144,8 @@ func (in *interceptor) TxCommit(ctx context.Context, tx driver.Tx) error {
 	err := tx.Commit()
 	if err != nil {
 		span.SetError(err)
+	} else {
+		span.SetStatus(sdk.StatusCodeOk, "")
 	}
 
 	return err
@@ -148,6 +162,8 @@ func (in *interceptor) TxRollback(ctx context.Context, tx driver.Tx) error {
 	err := tx.Rollback()
 	if err != nil {
 		span.SetError(err)
+	} else {
+		span.SetStatus(sdk.StatusCodeOk, "")
 	}
 
 	return err

--- a/sdk/instrumentation/database/sql/sql_test.go
+++ b/sdk/instrumentation/database/sql/sql_test.go
@@ -66,6 +66,7 @@ func TestQuerySuccess(t *testing.T) {
 	span := spans[0]
 	assert.Equal(t, "db:query", span.Name)
 	assert.Equal(t, sdk.SpanKindClient, span.Options.Kind)
+	assert.Equal(t, sdk.StatusCodeOk, span.Status.Code)
 
 	assert.Equal(t, "SELECT 1 WHERE 1 = ?", span.ReadAttribute("db.statement").(string))
 	assert.Equal(t, "sqlite", span.ReadAttribute("db.system").(string))
@@ -95,6 +96,7 @@ func TestExecSuccess(t *testing.T) {
 	assert.Equal(t, 1, len(spans))
 
 	span := spans[0]
+	assert.Equal(t, sdk.StatusCodeOk, span.Status.Code)
 	assert.Equal(t, sdk.SpanKindClient, span.Options.Kind)
 	assert.Equal(t, "db:exec", span.Name)
 	assert.Nil(t, span.ReadAttribute("error"))
@@ -142,6 +144,7 @@ func TestTxWithCommitSuccess(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		assert.Equal(t, sdk.SpanKindClient, spans[i].Options.Kind)
+		assert.Equal(t, sdk.StatusCodeOk, spans[i].Status.Code)
 		assert.Nil(t, spans[i].ReadAttribute("error"))
 	}
 
@@ -187,6 +190,7 @@ func TestTxWithRollbackSuccess(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		assert.Equal(t, sdk.SpanKindClient, spans[i].Options.Kind)
+		assert.Equal(t, sdk.StatusCodeOk, spans[i].Status.Code)
 		assert.Nil(t, spans[i].ReadAttribute("error"))
 	}
 

--- a/sdk/internal/mock/span.go
+++ b/sdk/internal/mock/span.go
@@ -18,7 +18,7 @@ type Span struct {
 	Name       string
 	Attributes map[string]interface{}
 	Options    sdk.SpanOptions
-	err        error
+	Err        error
 	Noop       bool
 	Status     Status
 	mux        *sync.Mutex
@@ -63,7 +63,7 @@ func (s *Span) SetStatus(code sdk.Code, description string) {
 }
 
 func (s *Span) SetError(err error) {
-	s.err = err
+	s.Err = err
 }
 
 func (s *Span) IsNoop() bool {


### PR DESCRIPTION
This PR adds support for span status code in SQL instrumentation.

After Go 1-RC2 the span does include status unset by default (see https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.0.0-RC2), we need to specifically set statusOK on success and statusError otherwise.