### PR TITLE
breaking: changes the filter interface for filters.

### DIFF
--- a/sdk/filter/filter.go
+++ b/sdk/filter/filter.go
@@ -8,5 +8,5 @@ type Filter interface {
 	EvaluateURLAndHeaders(span sdk.Span, url string, headers map[string][]string) bool
 
 	// EvaluateBody can be used to evaluate the body content
-	EvaluateBody(span sdk.Span, body []byte) bool
+	EvaluateBody(span sdk.Span, body []byte, headers map[string][]string) bool
 }

--- a/sdk/filter/multifilter.go
+++ b/sdk/filter/multifilter.go
@@ -25,9 +25,9 @@ func (m *MultiFilter) EvaluateURLAndHeaders(span sdk.Span, url string, headers m
 }
 
 // EvaluateBody runs body evaluators for each filter until one returns true
-func (m *MultiFilter) EvaluateBody(span sdk.Span, body []byte) bool {
+func (m *MultiFilter) EvaluateBody(span sdk.Span, body []byte, headers map[string][]string) bool {
 	for _, f := range (*m).filters {
-		if f.EvaluateBody(span, body) {
+		if f.EvaluateBody(span, body, headers) {
 			return true
 		}
 	}

--- a/sdk/filter/multifilter_test.go
+++ b/sdk/filter/multifilter_test.go
@@ -11,7 +11,7 @@ import (
 func TestMultiFilterEmpty(t *testing.T) {
 	f := NewMultiFilter()
 	assert.False(t, f.EvaluateURLAndHeaders(nil, "", nil))
-	assert.False(t, f.EvaluateBody(nil, nil))
+	assert.False(t, f.EvaluateBody(nil, nil, nil))
 }
 
 func TestMultiFilterStopsAfterTrue(t *testing.T) {
@@ -46,17 +46,17 @@ func TestMultiFilterStopsAfterTrue(t *testing.T) {
 			expectedBodyFilterResult: true,
 			multiFilter: NewMultiFilter(
 				mock.Filter{
-					BodyEvaluator: func(span sdk.Span, body []byte) bool {
+					BodyEvaluator: func(span sdk.Span, body []byte, headers map[string][]string) bool {
 						return false
 					},
 				},
 				mock.Filter{
-					BodyEvaluator: func(span sdk.Span, body []byte) bool {
+					BodyEvaluator: func(span sdk.Span, body []byte, headers map[string][]string) bool {
 						return true
 					},
 				},
 				mock.Filter{
-					BodyEvaluator: func(span sdk.Span, body []byte) bool {
+					BodyEvaluator: func(span sdk.Span, body []byte, headers map[string][]string) bool {
 						assert.Fail(t, "should not be called")
 						return false
 					},
@@ -68,7 +68,7 @@ func TestMultiFilterStopsAfterTrue(t *testing.T) {
 	for name, tCase := range tCases {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tCase.expectedURLAndHeadersFilterResult, tCase.multiFilter.EvaluateURLAndHeaders(nil, "", nil))
-			assert.Equal(t, tCase.expectedBodyFilterResult, tCase.multiFilter.EvaluateBody(nil, nil))
+			assert.Equal(t, tCase.expectedBodyFilterResult, tCase.multiFilter.EvaluateBody(nil, nil, nil))
 		})
 	}
 }

--- a/sdk/filter/noop.go
+++ b/sdk/filter/noop.go
@@ -13,6 +13,6 @@ func (NoopFilter) EvaluateURLAndHeaders(span sdk.Span, url string, headers map[s
 }
 
 // EvaluateBody that always returns false
-func (NoopFilter) EvaluateBody(span sdk.Span, body []byte) bool {
+func (NoopFilter) EvaluateBody(span sdk.Span, body []byte, headers map[string][]string) bool {
 	return false
 }

--- a/sdk/filter/noop_test.go
+++ b/sdk/filter/noop_test.go
@@ -9,5 +9,5 @@ import (
 func TestNoopFilter(t *testing.T) {
 	f := NoopFilter{}
 	assert.False(t, f.EvaluateURLAndHeaders(nil, "", nil))
-	assert.False(t, f.EvaluateBody(nil, nil))
+	assert.False(t, f.EvaluateBody(nil, nil, nil))
 }

--- a/sdk/instrumentation/google.golang.org/grpc/server.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server.go
@@ -95,8 +95,10 @@ func wrapHandler(
 			len(reqBody) > 0 && err == nil {
 			setTruncatedBodyAttribute("request", reqBody, int(dataCaptureConfig.BodyMaxSizeBytes.Value), span)
 
-			if filter.EvaluateBody(span, reqBody) {
-				return nil, status.Error(codes.PermissionDenied, "Permission Denied")
+			if md, ok := metadata.FromIncomingContext(ctx); ok {
+				if filter.EvaluateBody(span, reqBody, md) {
+					return nil, status.Error(codes.PermissionDenied, "Permission Denied")
+				}
 			}
 		}
 

--- a/sdk/instrumentation/google.golang.org/grpc/server_test.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server_test.go
@@ -112,7 +112,7 @@ func TestServerInterceptorFilter(t *testing.T) {
 		"body filter": {
 			expectedFilterResult: true,
 			multiFilter: filter.NewMultiFilter(mock.Filter{
-				BodyEvaluator: func(span sdk.Span, body []byte) bool {
+				BodyEvaluator: func(span sdk.Span, body []byte, headers map[string][]string) bool {
 					assert.Equal(t, "{\"name\":\"Pupo\"}", string(body))
 					return true
 				},

--- a/sdk/instrumentation/net/http/handler.go
+++ b/sdk/instrumentation/net/http/handler.go
@@ -90,7 +90,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// run body filters
-		if h.filter.EvaluateBody(span, body) {
+		if h.filter.EvaluateBody(span, body, headers) {
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}

--- a/sdk/instrumentation/net/http/handler_test.go
+++ b/sdk/instrumentation/net/http/handler_test.go
@@ -301,7 +301,7 @@ func TestServerRequestFilter(t *testing.T) {
 						assert.Equal(t, []string{"application/json"}, headers["Content-Type"])
 						return false
 					},
-					BodyEvaluator: func(span sdk.Span, body []byte) bool {
+					BodyEvaluator: func(span sdk.Span, body []byte, headers map[string][]string) bool {
 						assert.Equal(t, []byte("haha"), body)
 						return false
 					},
@@ -337,7 +337,7 @@ func TestServerRequestFilter(t *testing.T) {
 			body:         "haha",
 			options: &Options{
 				Filter: mock.Filter{
-					BodyEvaluator: func(span sdk.Span, body []byte) bool {
+					BodyEvaluator: func(span sdk.Span, body []byte, headers map[string][]string) bool {
 						return true
 					},
 				},

--- a/sdk/internal/mock/filter.go
+++ b/sdk/internal/mock/filter.go
@@ -4,13 +4,13 @@ import "github.com/hypertrace/goagent/sdk"
 
 type Filter struct {
 	URLAndHeadersEvaluator func(span sdk.Span, url string, headers map[string][]string) bool
-	BodyEvaluator          func(span sdk.Span, body []byte) bool
+	BodyEvaluator          func(span sdk.Span, body []byte, headers map[string][]string) bool
 }
 
 func (f Filter) EvaluateURLAndHeaders(span sdk.Span, url string, headers map[string][]string) bool {
 	return f.URLAndHeadersEvaluator != nil && f.URLAndHeadersEvaluator(span, url, headers)
 }
 
-func (f Filter) EvaluateBody(span sdk.Span, body []byte) bool {
-	return f.BodyEvaluator != nil && f.BodyEvaluator(span, body)
+func (f Filter) EvaluateBody(span sdk.Span, body []byte, headers map[string][]string) bool {
+	return f.BodyEvaluator != nil && f.BodyEvaluator(span, body, headers)
 }


### PR DESCRIPTION
This change allows to do header evaluation along with body evaluation to avoid expensive evaluations on body that end up wasted.
