### PR TITLE
match on content-type header "stems" instead of full header strings

### DIFF
--- a/sdk/instrumentation/net/http/contenttype.go
+++ b/sdk/instrumentation/net/http/contenttype.go
@@ -4,10 +4,14 @@ import (
 	"strings"
 )
 
-// contentTypeAllowList is the list of allowed content types in lowercase
+// contentTypeAllowList is the list of allowed "stems" of content types in lowercase.
+// Example headers that will match this include:
+// - application/json
+// - application/vnd.api+json
+// - application/x-www-form-urlencoded'
 var contentTypeAllowListLowerCase = []string{
-	"application/json",
-	"application/x-www-form-urlencoded",
+	"json",
+	"x-www-form-urlencoded",
 }
 
 // ShouldRecordBodyOfContentType checks if the body is meant

--- a/sdk/instrumentation/net/http/contenttype_test.go
+++ b/sdk/instrumentation/net/http/contenttype_test.go
@@ -22,6 +22,8 @@ func TestRecordingDecissionSuccessOnHeaderSet(t *testing.T) {
 		{"application/json", true},
 		{"application/json; charset=utf-8", true},
 		{"application/x-www-form-urlencoded", true},
+		{"application/vnd.api+json", true},
+		{"application/grpc+json", true},
 	}
 
 	for _, tCase := range tCases {
@@ -42,6 +44,7 @@ func TestRecordingDecissionSuccessOnHeaderAdd(t *testing.T) {
 		{[]string{"application/json; charset=utf-8"}, true},
 		{[]string{"application/x-www-form-urlencoded"}, true},
 		{[]string{"charset=utf-8", "application/json"}, true},
+		{[]string{"charset=utf-8", "application/vnd.api+json"}, true},
 	}
 
 	for _, tCase := range tCases {


### PR DESCRIPTION


## Description
To match other agents, we match on the "stem" of the content-type instead of the full name so we can cover all possible cases. eg. for `application/json` we use `json` so we can capture `application/vnd.api+json` as well.

### Testing
Unit tests

### Checklist:
- [ ✅ ] My changes generate no new warnings
- [ ✅ ] I have added tests that prove my fix is effective or that my feature works
- [ ] There are no dependent changes

