### PR TITLE
feat: adds support for body max processing size in bytes

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -23,7 +23,8 @@ var defaultConfig = agentconfig.AgentConfig{
 			Request:  agentconfig.Bool(true),
 			Response: agentconfig.Bool(true),
 		},
-		BodyMaxSizeBytes: agentconfig.Int32(131072),
+		BodyMaxSizeBytes:           agentconfig.Int32(131072),
+		BodyMaxProcessingSizeBytes: agentconfig.Int32(1048576),
 	},
 	Reporting: &agentconfig.Reporting{
 		Endpoint:          agentconfig.String("http://localhost:9411/api/v2/spans"),

--- a/examples/gin-server/go.mod
+++ b/examples/gin-server/go.mod
@@ -6,5 +6,5 @@ replace github.com/hypertrace/goagent => ../..
 
 require (
 	github.com/gin-gonic/gin v1.7.2
-	github.com/hypertrace/goagent v0.2.1
+	github.com/hypertrace/goagent v0.0.0-00010101000000-000000000000
 )

--- a/examples/gin-server/go.sum
+++ b/examples/gin-server/go.sum
@@ -88,8 +88,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hypertrace/agent-config/gen/go v0.0.0-20210928174043-f66d46bdfecb h1:0+2ExqTCP7CTMJiE4EFqUj2mOmlYKa5FJePxQdjrnrs=
-github.com/hypertrace/agent-config/gen/go v0.0.0-20210928174043-f66d46bdfecb/go.mod h1:LjKDF0vbkemwirXM+v4aH+ARjX9y8EwVTIe3BDrqj0I=
+github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e h1:RztUu5aZrCoOUP1+xmzvzTnq3fuhZ6AJUzAYOpT0/Eo=
+github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e/go.mod h1:LjKDF0vbkemwirXM+v4aH+ARjX9y8EwVTIe3BDrqj0I=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/examples/mux-server/go.sum
+++ b/examples/mux-server/go.sum
@@ -83,8 +83,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hypertrace/agent-config/gen/go v0.0.0-20210928174043-f66d46bdfecb h1:0+2ExqTCP7CTMJiE4EFqUj2mOmlYKa5FJePxQdjrnrs=
-github.com/hypertrace/agent-config/gen/go v0.0.0-20210928174043-f66d46bdfecb/go.mod h1:LjKDF0vbkemwirXM+v4aH+ARjX9y8EwVTIe3BDrqj0I=
+github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e h1:RztUu5aZrCoOUP1+xmzvzTnq3fuhZ6AJUzAYOpT0/Eo=
+github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e/go.mod h1:LjKDF0vbkemwirXM+v4aH+ARjX9y8EwVTIe3BDrqj0I=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=

--- a/examples/postgres-query/go.sum
+++ b/examples/postgres-query/go.sum
@@ -168,8 +168,8 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/hypertrace/agent-config/gen/go v0.0.0-20210928174043-f66d46bdfecb h1:0+2ExqTCP7CTMJiE4EFqUj2mOmlYKa5FJePxQdjrnrs=
-github.com/hypertrace/agent-config/gen/go v0.0.0-20210928174043-f66d46bdfecb/go.mod h1:LjKDF0vbkemwirXM+v4aH+ARjX9y8EwVTIe3BDrqj0I=
+github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e h1:RztUu5aZrCoOUP1+xmzvzTnq3fuhZ6AJUzAYOpT0/Eo=
+github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e/go.mod h1:LjKDF0vbkemwirXM+v4aH+ARjX9y8EwVTIe3BDrqj0I=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=

--- a/examples/sql-query/go.sum
+++ b/examples/sql-query/go.sum
@@ -83,8 +83,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hypertrace/agent-config/gen/go v0.0.0-20210928174043-f66d46bdfecb h1:0+2ExqTCP7CTMJiE4EFqUj2mOmlYKa5FJePxQdjrnrs=
-github.com/hypertrace/agent-config/gen/go v0.0.0-20210928174043-f66d46bdfecb/go.mod h1:LjKDF0vbkemwirXM+v4aH+ARjX9y8EwVTIe3BDrqj0I=
+github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e h1:RztUu5aZrCoOUP1+xmzvzTnq3fuhZ6AJUzAYOpT0/Eo=
+github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e/go.mod h1:LjKDF0vbkemwirXM+v4aH+ARjX9y8EwVTIe3BDrqj0I=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gin-gonic/gin v1.7.2
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/mux v1.8.0
-	github.com/hypertrace/agent-config/gen/go v0.0.0-20210928174043-f66d46bdfecb
+	github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.4
 	github.com/ngrok/sqlmw v0.0.0-20200129213757-d5c93a81bec6

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hypertrace/agent-config/gen/go v0.0.0-20210928174043-f66d46bdfecb h1:0+2ExqTCP7CTMJiE4EFqUj2mOmlYKa5FJePxQdjrnrs=
-github.com/hypertrace/agent-config/gen/go v0.0.0-20210928174043-f66d46bdfecb/go.mod h1:LjKDF0vbkemwirXM+v4aH+ARjX9y8EwVTIe3BDrqj0I=
+github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e h1:RztUu5aZrCoOUP1+xmzvzTnq3fuhZ6AJUzAYOpT0/Eo=
+github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e/go.mod h1:LjKDF0vbkemwirXM+v4aH+ARjX9y8EwVTIe3BDrqj0I=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/instrumentation/hypertrace/github.com/jackc/hyperpgx/go.sum
+++ b/instrumentation/hypertrace/github.com/jackc/hyperpgx/go.sum
@@ -168,8 +168,8 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/hypertrace/agent-config/gen/go v0.0.0-20210928174043-f66d46bdfecb h1:0+2ExqTCP7CTMJiE4EFqUj2mOmlYKa5FJePxQdjrnrs=
-github.com/hypertrace/agent-config/gen/go v0.0.0-20210928174043-f66d46bdfecb/go.mod h1:LjKDF0vbkemwirXM+v4aH+ARjX9y8EwVTIe3BDrqj0I=
+github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e h1:RztUu5aZrCoOUP1+xmzvzTnq3fuhZ6AJUzAYOpT0/Eo=
+github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e/go.mod h1:LjKDF0vbkemwirXM+v4aH+ARjX9y8EwVTIe3BDrqj0I=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=

--- a/instrumentation/opentelemetry/github.com/jackc/hyperpgx/go.sum
+++ b/instrumentation/opentelemetry/github.com/jackc/hyperpgx/go.sum
@@ -168,8 +168,8 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/hypertrace/agent-config/gen/go v0.0.0-20210928174043-f66d46bdfecb h1:0+2ExqTCP7CTMJiE4EFqUj2mOmlYKa5FJePxQdjrnrs=
-github.com/hypertrace/agent-config/gen/go v0.0.0-20210928174043-f66d46bdfecb/go.mod h1:LjKDF0vbkemwirXM+v4aH+ARjX9y8EwVTIe3BDrqj0I=
+github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e h1:RztUu5aZrCoOUP1+xmzvzTnq3fuhZ6AJUzAYOpT0/Eo=
+github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e/go.mod h1:LjKDF0vbkemwirXM+v4aH+ARjX9y8EwVTIe3BDrqj0I=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=

--- a/instrumentation/opentelemetry/net/hyperhttp/handler_test.go
+++ b/instrumentation/opentelemetry/net/hyperhttp/handler_test.go
@@ -15,21 +15,23 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-var emptyConfig = config.AgentConfig{
-	DataCapture: &config.DataCapture{
-		HttpHeaders: &config.Message{
-			Request:  config.Bool(false),
-			Response: config.Bool(false),
+func makeEmptyConfig() config.AgentConfig {
+	return config.AgentConfig{
+		DataCapture: &config.DataCapture{
+			HttpHeaders: &config.Message{
+				Request:  config.Bool(false),
+				Response: config.Bool(false),
+			},
+			HttpBody: &config.Message{
+				Request:  config.Bool(false),
+				Response: config.Bool(false),
+			},
 		},
-		HttpBody: &config.Message{
-			Request:  config.Bool(false),
-			Response: config.Bool(false),
-		},
-	},
+	}
 }
 
 func TestServerRequestIsSuccessfullyTraced(t *testing.T) {
-	cfg := emptyConfig
+	cfg := makeEmptyConfig()
 	cfg.DataCapture.HttpHeaders = &config.Message{
 		Request:  config.Bool(true),
 		Response: config.Bool(true),

--- a/instrumentation/opentelemetry/net/hyperhttp/handler_test.go
+++ b/instrumentation/opentelemetry/net/hyperhttp/handler_test.go
@@ -15,19 +15,27 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func TestServerRequestIsSuccessfullyTraced(t *testing.T) {
-	sdkconfig.InitConfig(&config.AgentConfig{
-		DataCapture: &config.DataCapture{
-			HttpHeaders: &config.Message{
-				Request:  config.Bool(true),
-				Response: config.Bool(true),
-			},
-			HttpBody: &config.Message{
-				Request:  config.Bool(false),
-				Response: config.Bool(false),
-			},
+var emptyConfig = config.AgentConfig{
+	DataCapture: &config.DataCapture{
+		HttpHeaders: &config.Message{
+			Request:  config.Bool(false),
+			Response: config.Bool(false),
 		},
-	})
+		HttpBody: &config.Message{
+			Request:  config.Bool(false),
+			Response: config.Bool(false),
+		},
+	},
+}
+
+func TestServerRequestIsSuccessfullyTraced(t *testing.T) {
+	cfg := emptyConfig
+	cfg.DataCapture.HttpHeaders = &config.Message{
+		Request:  config.Bool(true),
+		Response: config.Bool(true),
+	}
+
+	sdkconfig.InitConfig(&cfg)
 	defer sdkconfig.ResetConfig()
 
 	_, flusher := tracetesting.InitTracer()
@@ -61,6 +69,8 @@ func TestServerRequestIsSuccessfullyTraced(t *testing.T) {
 }
 
 func TestServerRecordsRequestAndResponseBodyAccordingly(t *testing.T) {
+	defer sdkconfig.ResetConfig()
+
 	_, flusher := tracetesting.InitTracer()
 
 	tCases := map[string]struct {
@@ -129,6 +139,8 @@ func TestServerRecordsRequestAndResponseBodyAccordingly(t *testing.T) {
 }
 
 func TestRequestExtractsIncomingHeadersSuccessfully(t *testing.T) {
+	defer sdkconfig.ResetConfig()
+
 	_, flusher := tracetesting.InitTracer()
 
 	h := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {})

--- a/sdk/instrumentation/google.golang.org/grpc/server.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server.go
@@ -96,9 +96,9 @@ func wrapHandler(
 			setTruncatedBodyAttribute("request", reqBody, int(dataCaptureConfig.BodyMaxSizeBytes.Value), span)
 
 			if md, ok := metadata.FromIncomingContext(ctx); ok {
-				var processingBody []byte
-				if int(dataCaptureConfig.BodyMaxProcessingSizeBytes.Value) > len(reqBody) {
-					processingBody = reqBody
+				processingBody := reqBody
+				if int(dataCaptureConfig.BodyMaxProcessingSizeBytes.Value) < len(reqBody) {
+					processingBody = reqBody[:dataCaptureConfig.BodyMaxProcessingSizeBytes.Value]
 				}
 				if filter.EvaluateBody(span, processingBody, md) {
 					return nil, status.Error(codes.PermissionDenied, "Permission Denied")

--- a/sdk/instrumentation/google.golang.org/grpc/server.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server.go
@@ -96,7 +96,11 @@ func wrapHandler(
 			setTruncatedBodyAttribute("request", reqBody, int(dataCaptureConfig.BodyMaxSizeBytes.Value), span)
 
 			if md, ok := metadata.FromIncomingContext(ctx); ok {
-				if filter.EvaluateBody(span, reqBody, md) {
+				var processingBody []byte
+				if int(dataCaptureConfig.BodyMaxProcessingSizeBytes.Value) > len(reqBody) {
+					processingBody = reqBody
+				}
+				if filter.EvaluateBody(span, processingBody, md) {
 					return nil, status.Error(codes.PermissionDenied, "Permission Denied")
 				}
 			}

--- a/sdk/instrumentation/google.golang.org/grpc/server_test.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server_test.go
@@ -178,6 +178,9 @@ func TestServerInterceptorFilterWithMaxProcessingBodyLen(t *testing.T) {
 
 	cfg := &config.AgentConfig{
 		DataCapture: &config.DataCapture{
+			RpcBody: &config.Message{
+				Request: config.Bool(true),
+			},
 			BodyMaxProcessingSizeBytes: config.Int32(1),
 		},
 	}
@@ -191,8 +194,8 @@ func TestServerInterceptorFilterWithMaxProcessingBodyLen(t *testing.T) {
 		grpc.UnaryInterceptor(
 			WrapUnaryServerInterceptor(mockUnaryInterceptor, mock.SpanFromContext, &Options{Filter: mock.Filter{
 				BodyEvaluator: func(span sdk.Span, body []byte, headers map[string][]string) bool {
-					assert.Empty(t, body)
-					return true
+					assert.Equal(t, "{", string(body)) // body is truncated
+					return false
 				},
 			}}),
 		),

--- a/sdk/instrumentation/google.golang.org/grpc/server_test.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server_test.go
@@ -222,6 +222,8 @@ func TestServerInterceptorFilterWithMaxProcessingBodyLen(t *testing.T) {
 	_, err = client.SayHello(ctx, &helloworld.HelloRequest{
 		Name: "Pupo",
 	})
+
+	assert.NoError(t, err)
 }
 
 func TestServerHandlerHelloWorldSuccess(t *testing.T) {

--- a/sdk/instrumentation/net/http/handler.go
+++ b/sdk/instrumentation/net/http/handler.go
@@ -89,8 +89,13 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			setTruncatedBodyAttribute("request", body, int(h.dataCaptureConfig.BodyMaxSizeBytes.Value), span)
 		}
 
+		processingBody := body
+		if int(h.dataCaptureConfig.BodyMaxProcessingSizeBytes.Value) < len(body) {
+			processingBody = body[:h.dataCaptureConfig.BodyMaxProcessingSizeBytes.Value]
+		}
+
 		// run body filters
-		if h.filter.EvaluateBody(span, body, headers) {
+		if h.filter.EvaluateBody(span, processingBody, headers) {
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}

--- a/sdk/instrumentation/net/http/handler_test.go
+++ b/sdk/instrumentation/net/http/handler_test.go
@@ -9,6 +9,7 @@ import (
 
 	config "github.com/hypertrace/agent-config/gen/go/v1"
 	"github.com/hypertrace/goagent/sdk"
+	internalconfig "github.com/hypertrace/goagent/sdk/internal/config"
 	"github.com/hypertrace/goagent/sdk/internal/mock"
 	"github.com/stretchr/testify/assert"
 )
@@ -22,7 +23,8 @@ var emptyTestConfig = &config.DataCapture{
 		Request:  config.Bool(false),
 		Response: config.Bool(false),
 	},
-	BodyMaxSizeBytes: config.Int32(1000),
+	BodyMaxSizeBytes:           config.Int32(1000),
+	BodyMaxProcessingSizeBytes: config.Int32(1000),
 }
 
 var _ http.Handler = &mockHandler{}
@@ -40,6 +42,8 @@ func (h *mockHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 }
 
 func TestServerRequestWithNilBodyIsntChanged(t *testing.T) {
+	defer internalconfig.ResetConfig()
+
 	h := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		assert.Nil(t, r.Body)
 	})
@@ -59,6 +63,8 @@ func TestServerRequestWithNilBodyIsntChanged(t *testing.T) {
 }
 
 func TestServerRequestIsSuccessfullyTraced(t *testing.T) {
+	defer internalconfig.ResetConfig()
+
 	h := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Add("request_id", "abc123xyz")
 		rw.WriteHeader(202)
@@ -67,17 +73,7 @@ func TestServerRequestIsSuccessfullyTraced(t *testing.T) {
 	})
 
 	wh, _ := WrapHandler(h, mock.SpanFromContext, &Options{}).(*handler)
-	wh.dataCaptureConfig = &config.DataCapture{
-		HttpHeaders: &config.Message{
-			Request:  config.Bool(false),
-			Response: config.Bool(false),
-		},
-		HttpBody: &config.Message{
-			Request:  config.Bool(false),
-			Response: config.Bool(false),
-		},
-	}
-
+	wh.dataCaptureConfig = emptyTestConfig
 	ih := &mockHandler{baseHandler: wh}
 
 	r, _ := http.NewRequest("GET", "http://traceable.ai/foo?user_id=1", strings.NewReader("test_request_body"))
@@ -98,21 +94,14 @@ func TestServerRequestIsSuccessfullyTraced(t *testing.T) {
 }
 
 func TestHostIsSuccessfullyRecorded(t *testing.T) {
+	defer internalconfig.ResetConfig()
+
 	h := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		assert.Nil(t, r.Body)
 	})
 
 	wh, _ := WrapHandler(h, mock.SpanFromContext, &Options{}).(*handler)
-	wh.dataCaptureConfig = &config.DataCapture{
-		HttpHeaders: &config.Message{
-			Request:  config.Bool(false),
-			Response: config.Bool(false),
-		},
-		HttpBody: &config.Message{
-			Request:  config.Bool(true),
-			Response: config.Bool(false),
-		},
-	}
+	wh.dataCaptureConfig = emptyTestConfig
 
 	ih := &mockHandler{baseHandler: wh}
 
@@ -130,6 +119,8 @@ func TestHostIsSuccessfullyRecorded(t *testing.T) {
 }
 
 func TestServerRequestHeadersAreSuccessfullyRecorded(t *testing.T) {
+	defer internalconfig.ResetConfig()
+
 	tCases := []struct {
 		captureHTTPHeadersRequestConfig  bool
 		captureHTTPHeadersResponseConfig bool
@@ -147,16 +138,10 @@ func TestServerRequestHeadersAreSuccessfullyRecorded(t *testing.T) {
 
 		wh, _ := WrapHandler(h, mock.SpanFromContext, &Options{}).(*handler)
 		ih := &mockHandler{baseHandler: wh}
-		wh.dataCaptureConfig = &config.DataCapture{
-			HttpHeaders: &config.Message{
-				Request:  config.Bool(tCase.captureHTTPHeadersRequestConfig),
-				Response: config.Bool(tCase.captureHTTPHeadersResponseConfig),
-			},
-			HttpBody: &config.Message{
-				Request:  config.Bool(false),
-				Response: config.Bool(false),
-			},
-			BodyMaxSizeBytes: config.Int32(1000),
+		wh.dataCaptureConfig = emptyTestConfig
+		wh.dataCaptureConfig.HttpHeaders = &config.Message{
+			Request:  config.Bool(tCase.captureHTTPHeadersRequestConfig),
+			Response: config.Bool(tCase.captureHTTPHeadersResponseConfig),
 		}
 
 		r, _ := http.NewRequest("GET", "http://traceable.ai/foo?user_id=1", strings.NewReader("test_request_body"))
@@ -241,16 +226,10 @@ func TestServerRecordsRequestAndResponseBodyAccordingly(t *testing.T) {
 			})
 
 			wh, _ := WrapHandler(h, mock.SpanFromContext, &Options{}).(*handler)
-			wh.dataCaptureConfig = &config.DataCapture{
-				HttpBody: &config.Message{
-					Request:  config.Bool(tCase.captureHTTPBodyConfig),
-					Response: config.Bool(tCase.captureHTTPBodyConfig),
-				},
-				HttpHeaders: &config.Message{
-					Request:  config.Bool(false),
-					Response: config.Bool(false),
-				},
-				BodyMaxSizeBytes: config.Int32(1000),
+			wh.dataCaptureConfig = emptyTestConfig
+			wh.dataCaptureConfig.HttpBody = &config.Message{
+				Request:  config.Bool(tCase.captureHTTPBodyConfig),
+				Response: config.Bool(tCase.captureHTTPBodyConfig),
 			}
 			ih := &mockHandler{baseHandler: wh}
 
@@ -372,4 +351,33 @@ func TestServerRequestFilter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProcessingBodyIsTrimmed(t *testing.T) {
+	defer internalconfig.ResetConfig()
+
+	bodyMaxProcessingSizeBytes := 1
+
+	h := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {})
+
+	wh, _ := WrapHandler(h, mock.SpanFromContext, &Options{
+		Filter: mock.Filter{
+			BodyEvaluator: func(span sdk.Span, body []byte, headers map[string][]string) bool {
+				assert.Len(t, body, bodyMaxProcessingSizeBytes)
+				return true
+			},
+		},
+	}).(*handler)
+	wh.dataCaptureConfig = emptyTestConfig
+	wh.dataCaptureConfig.HttpBody.Request = config.Bool(true)
+	wh.dataCaptureConfig.BodyMaxProcessingSizeBytes = config.Int32(int32(bodyMaxProcessingSizeBytes))
+
+	ih := &mockHandler{baseHandler: wh}
+
+	r, _ := http.NewRequest("GET", "http://traceable.ai/foo?user_id=1", strings.NewReader("{\"foo\":\"bar\"}"))
+	r.Header.Add("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+
+	ih.ServeHTTP(w, r)
 }

--- a/sdk/instrumentation/net/http/handler_test.go
+++ b/sdk/instrumentation/net/http/handler_test.go
@@ -363,7 +363,7 @@ func TestProcessingBodyIsTrimmed(t *testing.T) {
 	wh, _ := WrapHandler(h, mock.SpanFromContext, &Options{
 		Filter: mock.Filter{
 			BodyEvaluator: func(span sdk.Span, body []byte, headers map[string][]string) bool {
-				assert.Len(t, body, bodyMaxProcessingSizeBytes)
+				assert.Equal(t, "{", string(body)) // body is truncated
 				return true
 			},
 		},


### PR DESCRIPTION
Capture all bytes up to `max_processing_size` (1mb default) in memory and pass that through the blocking code.  Any data after `max_processing_size` should not be captured.  Only the value of `body_max_size_bytes` (128K default) should be added to the span attribute.