### PR TITLE
chore: more comprehensive mysql example with an http-server before the db

### DIFF
--- a/examples/sql-query/go.mod
+++ b/examples/sql-query/go.mod
@@ -6,5 +6,6 @@ replace github.com/hypertrace/goagent => ../..
 
 require (
 	github.com/go-sql-driver/mysql v1.5.0
+	github.com/gorilla/mux v1.8.0
 	github.com/hypertrace/goagent v0.0.0-00010101000000-000000000000
 )

--- a/examples/sql-query/go.sum
+++ b/examples/sql-query/go.sum
@@ -38,6 +38,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
@@ -48,12 +49,10 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.7.2/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.1 h1:DX7uPQ4WgAWfoh+NGGlbJQswnYIVvz0SRlLS3rPZQDA=
 github.com/go-logr/logr v1.2.1/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.2.2 h1:ahHml/yUpnlb96Rp8HCvtYVPY8ZYpxq3g7UYchIYwbs=
-github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/stdr v1.2.0 h1:j4LrlVXgrbIWO83mmQUnK0Hi+YnbD+vzrE1z/EphbFE=
 github.com/go-logr/stdr v1.2.0/go.mod h1:YkVgnZu1ZjjL7xTxrfm/LLZBfkhTqSR1ydtm6jTKKwI=
-github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
-github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
@@ -98,6 +97,7 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
@@ -105,8 +105,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e h1:RztUu5aZrCoOUP1+xmzvzTnq3fuhZ6AJUzAYOpT0/Eo=
-github.com/hypertrace/agent-config/gen/go v0.0.0-20211201093046-a7ed863ff59e/go.mod h1:LjKDF0vbkemwirXM+v4aH+ARjX9y8EwVTIe3BDrqj0I=
+github.com/hypertrace/agent-config/gen/go v0.0.0-20220209183558-95cc7dcabb51 h1:be7Skj74loff4ogxQurGjhB/1jBFySN/wA8xSqDz2t4=
+github.com/hypertrace/agent-config/gen/go v0.0.0-20220209183558-95cc7dcabb51/go.mod h1:mAjMCmZXb0eL7I20pNuPz0tTPx8Ow3IE1J5fHhnLyZs=
 github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
 github.com/jcmturner/dnsutils/v2 v2.0.0/go.mod h1:b0TnjGOvI/n42bZa+hmXL+kFJZsFT7G4t3HTlQ184QM=
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
@@ -182,6 +182,7 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.28.0/go.mod h1:vEhqr0m4eTc+DWxfsXoXue2GBgV2uUwVznkGIHW/e5w=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.28.0 h1:hpEoMBvKLC6CqFZogJypr9IHwwSNF3ayEkNzD502QAM=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.28.0/go.mod h1:Ihno+mNBfZlT0Qot3XyRTdZ/9U/Cg2Pfgj75DTdIfq4=
 go.opentelemetry.io/contrib/propagators/b3 v1.3.0 h1:f+JfMSDNm2u+fekYYjyoixk+DWDTDAGD3SC50y61koE=
 go.opentelemetry.io/contrib/propagators/b3 v1.3.0/go.mod h1:qzi0km8qO3l2jxB5aDg4Q9xyqV4HKnCWZYpVYDTUIT0=
@@ -197,7 +198,9 @@ go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.3.0 h1:Kte45gGM12Ks0pZn
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.3.0/go.mod h1:PQLM+xJ3EMSZU9rMevmw+4nH1efyp23CW/nD9BlB3sg=
 go.opentelemetry.io/otel/exporters/zipkin v1.3.0 h1:uOD28dZ7yIKITTcUS6MeAGNHYy3uhP7DTkhcJM6onlQ=
 go.opentelemetry.io/otel/exporters/zipkin v1.3.0/go.mod h1:LxGGfHIYbvsFnrJtBcazb0yG24xHdDGrT/H6RB9r3+8=
+go.opentelemetry.io/otel/internal/metric v0.26.0 h1:dlrvawyd/A+X8Jp0EBT4wWEe4k5avYaXsXrBr4dbfnY=
 go.opentelemetry.io/otel/internal/metric v0.26.0/go.mod h1:CbBP6AxKynRs3QCbhklyLUtpfzbqCLiafV9oY2Zj1Jk=
+go.opentelemetry.io/otel/metric v0.26.0 h1:VaPYBTvA13h/FsiWfxa3yZnZEm15BhStD8JZQSA773M=
 go.opentelemetry.io/otel/metric v0.26.0/go.mod h1:c6YL0fhRo4YVoNs6GoByzUgBp36hBL523rECoZA5UWg=
 go.opentelemetry.io/otel/sdk v1.3.0 h1:3278edCoH89MEJ0Ky8WQXVmDQv3FX4ZJ3Pp+9fJreAI=
 go.opentelemetry.io/otel/sdk v1.3.0/go.mod h1:rIo4suHNhQwBIPg9axF8V9CA72Wz2mKF1teNrup8yzs=

--- a/examples/sql-query/main.go
+++ b/examples/sql-query/main.go
@@ -3,33 +3,77 @@ package main
 import (
 	"context"
 	"database/sql"
-	"database/sql/driver"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
-
+	"github.com/gorilla/mux"
 	"github.com/hypertrace/goagent/config"
 	"github.com/hypertrace/goagent/instrumentation/hypertrace"
 	"github.com/hypertrace/goagent/instrumentation/hypertrace/database/hypersql"
+	"github.com/hypertrace/goagent/instrumentation/hypertrace/net/hyperhttp"
 )
 
-// Run docker run mysql
+const mysqlLoopCount int = 5
+
+// Run docker run mysql before invoking this
 func main() {
 	cfg := config.Load()
-	cfg.ServiceName = config.String("querier")
+	cfg.ServiceName = config.String("http-server-with-mysql")
 
 	flusher := hypertrace.Init(cfg)
 	defer flusher()
 
-	var (
-		driver driver.Driver
-		db     *sql.DB
-	)
+	// Set up mysql connection
+	db := dbConn()
+	defer db.Close()
 
+	r := mux.NewRouter()
+	fooHandlerFunc := func(w http.ResponseWriter, r *http.Request) {
+		fooHandler(db, w, r)
+	}
+	r.Handle("/foo", hyperhttp.NewHandler(
+		http.HandlerFunc(fooHandlerFunc),
+		"/foo",
+	))
+	log.Fatal(http.ListenAndServe(":8081", r))
+}
+
+type person struct {
+	Name string `json:"name"`
+}
+
+func fooHandler(db *sql.DB, w http.ResponseWriter, r *http.Request) {
+	sBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	defer r.Body.Close()
+
+	p := &person{}
+	err = json.Unmarshal(sBody, p)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	mysqlLoop(db, r.Context())
+
+	<-time.After(20 * time.Millisecond)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(fmt.Sprintf("{\"message\": \"Hello %s\"}", p.Name)))
+}
+
+func dbConn() (db *sql.DB) {
 	// Explicitly wrap the MySQLDriver driver with hypersql.
-	driver = hypersql.Wrap(&mysql.MySQLDriver{})
+	driver := hypersql.Wrap(&mysql.MySQLDriver{})
 
 	// Register our hypersql wrapper as a database driver.
 	sql.Register("ht-mysql", driver)
@@ -39,22 +83,45 @@ func main() {
 		log.Fatalf("failed to connect the DB: %v", err)
 	}
 
-	const dbPingRetries = 5
-	for i := 0; i <= dbPingRetries; i++ {
-		if err := db.Ping(); err != nil && i == dbPingRetries {
-			log.Fatalf("failed to ping the DB: %v", err)
-		}
-		time.Sleep(time.Second)
-	}
-
-	rows, err := db.QueryContext(context.Background(), "SELECT 'Hi there :)'")
+	log.Println("Connecting to db")
 	if err != nil {
-		log.Fatalf("failed to retrieve message: %v", err)
+		log.Println(err.Error())
 	}
 
-	for rows.Next() {
-		m := new(string)
-		rows.Scan(m)
-		fmt.Println(*m)
+	_, err2 := db.ExecContext(context.Background(), "CREATE DATABASE IF NOT EXISTS user")
+	if err2 != nil {
+		log.Println(err2.Error())
+	}
+
+	_, err3 := db.ExecContext(context.Background(), "USE user")
+	if err3 != nil {
+		log.Println(err3.Error())
+	}
+
+	_, err4 := db.ExecContext(context.Background(), "CREATE TABLE IF NOT EXISTS Persons (FirstName varchar(255), LastName varchar(255), phoneNumber varchar(255), country varchar(255), serviceCount int)")
+	if err4 != nil {
+		log.Println(err4.Error())
+	}
+
+	return db
+}
+
+// mysqlLoop takes in a context which may contain tracing headers which are used to correlate to the caller.
+// The caller can be an http server handler function for example.
+func mysqlLoop(db *sql.DB, ctx context.Context) {
+	for i := 0; i < mysqlLoopCount; i++ {
+		_, err1 := db.ExecContext(ctx, "INSERT INTO Persons (FirstName, LastName, phoneNumber, country, serviceCount) VALUES ('Alice', 'Tom B. Erichsen', '1234', 'India', 0)")
+		if err1 != nil {
+			log.Println(err1.Error())
+		}
+		_, err2 := db.ExecContext(ctx, "SELECT * FROM Persons")
+		if err2 != nil {
+			log.Println(err2.Error())
+		}
+
+		_, err3 := db.ExecContext(ctx, "DELETE FROM Persons WHERE FirstName = 'Alice'")
+		if err3 != nil {
+			log.Println(err3.Error())
+		}
 	}
 }


### PR DESCRIPTION
## Description
More comprehensive mysql example with an http-server before the db. The point is to pass down the context and invoke `ExecContext` instead `Exec` when making the db calls so that they can be correlated to the server calls.