### PR TITLE
feat: modify RegisterService api to return the TracerProvider as well

### DIFF
--- a/instrumentation/hypertrace/google.golang.org/hypergrpc/client.go
+++ b/instrumentation/hypertrace/google.golang.org/hypergrpc/client.go
@@ -13,5 +13,6 @@ func UnaryClientInterceptor() grpc.UnaryClientInterceptor {
 	return sdkgrpc.WrapUnaryClientInterceptor(
 		otelgrpc.UnaryClientInterceptor(),
 		opentelemetry.SpanFromContext,
+		map[string]string{},
 	)
 }

--- a/instrumentation/hypertrace/google.golang.org/hypergrpc/server.go
+++ b/instrumentation/hypertrace/google.golang.org/hypergrpc/server.go
@@ -19,5 +19,6 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
 		otelgrpc.UnaryServerInterceptor(),
 		opentelemetry.SpanFromContext,
 		o.toSDKOptions(),
+		map[string]string{},
 	)
 }

--- a/instrumentation/hypertrace/init.go
+++ b/instrumentation/hypertrace/init.go
@@ -9,3 +9,5 @@ import (
 var Init = opentelemetry.Init
 
 var RegisterService = opentelemetry.RegisterService
+
+var RegisterServiceAndReturnTracerProvider = opentelemetry.RegisterServiceAndReturnTracerProvider

--- a/instrumentation/hypertrace/init.go
+++ b/instrumentation/hypertrace/init.go
@@ -9,5 +9,3 @@ import (
 var Init = opentelemetry.Init
 
 var RegisterService = opentelemetry.RegisterService
-
-var RegisterServiceAndReturnTracerProvider = opentelemetry.RegisterServiceAndReturnTracerProvider

--- a/instrumentation/opentelemetry/google.golang.org/hypergrpc/client.go
+++ b/instrumentation/opentelemetry/google.golang.org/hypergrpc/client.go
@@ -9,5 +9,5 @@ import (
 // WrapUnaryClientInterceptor returns a new unary client interceptor that will
 // complement existing OpenTelemetry instrumentation
 func WrapUnaryClientInterceptor(delegate grpc.UnaryClientInterceptor) grpc.UnaryClientInterceptor {
-	return sdkgrpc.WrapUnaryClientInterceptor(delegate, opentelemetry.SpanFromContext)
+	return sdkgrpc.WrapUnaryClientInterceptor(delegate, opentelemetry.SpanFromContext, map[string]string{})
 }

--- a/instrumentation/opentelemetry/google.golang.org/hypergrpc/server.go
+++ b/instrumentation/opentelemetry/google.golang.org/hypergrpc/server.go
@@ -9,5 +9,5 @@ import (
 // WrapUnaryServerInterceptor returns a new unary server interceptor that will
 // complement existing OpenTelemetry instrumentation
 func WrapUnaryServerInterceptor(delegate grpc.UnaryServerInterceptor, options *sdkgrpc.Options) grpc.UnaryServerInterceptor {
-	return sdkgrpc.WrapUnaryServerInterceptor(delegate, opentelemetry.SpanFromContext, options)
+	return sdkgrpc.WrapUnaryServerInterceptor(delegate, opentelemetry.SpanFromContext, options, map[string]string{})
 }

--- a/instrumentation/opentelemetry/init.go
+++ b/instrumentation/opentelemetry/init.go
@@ -260,51 +260,10 @@ func RegisterService(serviceName string, resourceAttributes map[string]string) (
 func RegisterServiceWithSpanProcessorWrapper(serviceName string, resourceAttributes map[string]string, wrapper SpanProcessorWrapper) (sdk.StartSpan, error) {
 	spanStarter, _, err := RegisterServiceWithSpanProcessorWrapperAndReturnTracerProvider(serviceName, resourceAttributes, wrapper)
 	return spanStarter, err
-	// mu.Lock()
-	// defer mu.Unlock()
-	// if !initialized {
-	// 	return nil, fmt.Errorf("hypertrace hadn't been initialized")
-	// }
-
-	// if !enabled {
-	// 	return NoopStartSpan, nil
-	// }
-
-	// if _, ok := traceProviders[serviceName]; ok {
-	// 	return nil, fmt.Errorf("service %v already initialized", serviceName)
-	// }
-
-	// exporter, err := exporterFactory()
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-
-	// sp := sdktrace.NewBatchSpanProcessor(exporter, sdktrace.WithBatchTimeout(batchTimeout))
-	// if wrapper != nil {
-	// 	sp = &spanProcessorWithWrapper{wrapper, sp}
-	// }
-
-	// resources, err := resource.New(
-	// 	context.Background(),
-	// 	resource.WithAttributes(createResources(serviceName, resourceAttributes)...),
-	// )
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-	// tp := sdktrace.NewTracerProvider(
-	// 	sdktrace.WithSampler(globalSampler),
-	// 	sdktrace.WithSpanProcessor(sp),
-	// 	sdktrace.WithResource(resources),
-	// )
-
-	// traceProviders[serviceName] = tp
-	// return startSpan(func() trace.TracerProvider {
-	// 	return tp
-	// }), nil
 }
 
-// RegisterServiceWithSpanProcessorWrapper creates tracerprovider for a new service with a wrapper over opentelemetry span processor
-// and returns a func which can be used to create spans
+// RegisterServiceWithSpanProcessorWrapperAndReturnTracerProvider creates tracerprovider for a new service with a wrapper over opentelemetry span processor
+// and returns a func which can be used to create spans. It returns the TracerProvider as well
 func RegisterServiceWithSpanProcessorWrapperAndReturnTracerProvider(serviceName string, resourceAttributes map[string]string,
 	wrapper SpanProcessorWrapper) (sdk.StartSpan, trace.TracerProvider, error) {
 	mu.Lock()

--- a/instrumentation/opentelemetry/init.go
+++ b/instrumentation/opentelemetry/init.go
@@ -244,27 +244,14 @@ func createResources(serviceName string, resources map[string]string) []attribut
 	return retValues
 }
 
-// RegisterServiceAndReturnTracerProvider creates tracerprovider for a new service and returns a func which can be used to create spans
-// + a tracer provider
-func RegisterServiceAndReturnTracerProvider(serviceName string, resourceAttributes map[string]string) (sdk.StartSpan, trace.TracerProvider, error) {
-	return RegisterServiceWithSpanProcessorWrapperAndReturnTracerProvider(serviceName, resourceAttributes, nil)
-}
-
-// RegisterService creates tracerprovider for a new service and returns a func which can be used to create spans
-func RegisterService(serviceName string, resourceAttributes map[string]string) (sdk.StartSpan, error) {
+// RegisterService creates tracerprovider for a new service and returns a func which can be used to create spans and the TracerProvider
+func RegisterService(serviceName string, resourceAttributes map[string]string) (sdk.StartSpan, trace.TracerProvider, error) {
 	return RegisterServiceWithSpanProcessorWrapper(serviceName, resourceAttributes, nil)
 }
 
-// RegisterServiceWithSpanProcessorWrapper creates tracerprovider for a new service with a wrapper over opentelemetry span processor
-// and returns a func which can be used to create spans
-func RegisterServiceWithSpanProcessorWrapper(serviceName string, resourceAttributes map[string]string, wrapper SpanProcessorWrapper) (sdk.StartSpan, error) {
-	spanStarter, _, err := RegisterServiceWithSpanProcessorWrapperAndReturnTracerProvider(serviceName, resourceAttributes, wrapper)
-	return spanStarter, err
-}
-
-// RegisterServiceWithSpanProcessorWrapperAndReturnTracerProvider creates tracerprovider for a new service with a wrapper over opentelemetry span processor
-// and returns a func which can be used to create spans. It returns the TracerProvider as well
-func RegisterServiceWithSpanProcessorWrapperAndReturnTracerProvider(serviceName string, resourceAttributes map[string]string,
+// RegisterServiceWithSpanProcessorWrapper creates a tracerprovider for a new service with a wrapper over opentelemetry span processor
+// and returns a func which can be used to create spans and the TracerProvider
+func RegisterServiceWithSpanProcessorWrapper(serviceName string, resourceAttributes map[string]string,
 	wrapper SpanProcessorWrapper) (sdk.StartSpan, trace.TracerProvider, error) {
 	mu.Lock()
 	defer mu.Unlock()

--- a/instrumentation/opentelemetry/init_test.go
+++ b/instrumentation/opentelemetry/init_test.go
@@ -12,6 +12,7 @@ import (
 
 	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,7 +38,7 @@ func ExampleRegisterService() {
 	shutdown := Init(cfg)
 	defer shutdown()
 
-	_, err := RegisterService("custom_service", map[string]string{"test1": "val1"})
+	_, _, err := RegisterService("custom_service", map[string]string{"test1": "val1"})
 	if err != nil {
 		log.Fatalf("Error while initializing service: %v", err)
 	}
@@ -49,8 +50,9 @@ func TestInitDisabledAgent(t *testing.T) {
 	shutdown := Init(cfg)
 	defer shutdown()
 
-	startSpan, err := RegisterService("test_service", nil)
+	startSpan, tp, err := RegisterService("test_service", nil)
 	require.NoError(t, err)
+	assert.NotEqual(t, trace.NewNoopTracerProvider(), tp)
 	_, s, _ := startSpan(context.Background(), "test_span", nil)
 	require.NoError(t, err)
 	assert.True(t, s.IsNoop())
@@ -78,7 +80,7 @@ func TestOtlpService(t *testing.T) {
 	shutdown := Init(cfg)
 	defer shutdown()
 
-	_, err := RegisterService("custom_service", map[string]string{"test1": "val1"})
+	_, _, err := RegisterService("custom_service", map[string]string{"test1": "val1"})
 	if err != nil {
 		log.Fatalf("Error while initializing service: %v", err)
 	}
@@ -138,11 +140,12 @@ func TestMultipleTraceProviders(t *testing.T) {
 	_, _, spanEnder := StartSpan(context.Background(), "example_span", nil)
 	spanEnder()
 
-	startServiceSpan, err := RegisterService("custom_service", map[string]string{"test1": "val1"})
+	startServiceSpan, tp, err := RegisterService("custom_service", map[string]string{"test1": "val1"})
 	assert.NoError(t, err)
 	assert.NotNil(t, startServiceSpan)
 	assert.True(t, initialized)
 	assert.Equal(t, 1, len(traceProviders))
+	assert.NotEqual(t, trace.NewNoopTracerProvider(), tp)
 
 	_, _, serviceSpanEnder := startServiceSpan(context.Background(), "my_span", nil)
 	serviceSpanEnder()
@@ -180,7 +183,7 @@ func TestMultipleTraceProvidersCallAfterShutdown(t *testing.T) {
 	assert.True(t, initialized)
 	assert.Equal(t, 0, len(traceProviders))
 
-	startServiceSpan, err := RegisterService("custom_service", map[string]string{"test1": "val1"})
+	startServiceSpan, _, err := RegisterService("custom_service", map[string]string{"test1": "val1"})
 	assert.NoError(t, err)
 	assert.NotNil(t, startServiceSpan)
 	assert.True(t, initialized)
@@ -347,7 +350,7 @@ func TestInitWithSpanProcessorWrapper(t *testing.T) {
 	assert.Equal(t, 1, wrapper.onEndCount)
 
 	// test wrapper is called for spans created by service trace provider
-	startSpan, err := RegisterServiceWithSpanProcessorWrapper("custom_service", map[string]string{"test1": "val1"}, wrapper)
+	startSpan, _, err := RegisterServiceWithSpanProcessorWrapper("custom_service", map[string]string{"test1": "val1"}, wrapper)
 	if err != nil {
 		log.Fatalf("Error while initializing service: %v", err)
 	}

--- a/instrumentation/opentelemetry/init_test.go
+++ b/instrumentation/opentelemetry/init_test.go
@@ -52,7 +52,7 @@ func TestInitDisabledAgent(t *testing.T) {
 
 	startSpan, tp, err := RegisterService("test_service", nil)
 	require.NoError(t, err)
-	assert.NotEqual(t, trace.NewNoopTracerProvider(), tp)
+	assert.Equal(t, trace.NewNoopTracerProvider(), tp)
 	_, s, _ := startSpan(context.Background(), "test_span", nil)
 	require.NoError(t, err)
 	assert.True(t, s.IsNoop())
@@ -80,7 +80,8 @@ func TestOtlpService(t *testing.T) {
 	shutdown := Init(cfg)
 	defer shutdown()
 
-	_, _, err := RegisterService("custom_service", map[string]string{"test1": "val1"})
+	_, tp, err := RegisterService("custom_service", map[string]string{"test1": "val1"})
+	assert.NotEqual(t, trace.NewNoopTracerProvider(), tp)
 	if err != nil {
 		log.Fatalf("Error while initializing service: %v", err)
 	}

--- a/sdk/instrumentation/google.golang.org/grpc/client.go
+++ b/sdk/instrumentation/google.golang.org/grpc/client.go
@@ -13,7 +13,8 @@ import (
 
 // WrapUnaryClientInterceptor returns an interceptor that records the request and response message's body
 // and serialize it as JSON.
-func WrapUnaryClientInterceptor(delegateInterceptor grpc.UnaryClientInterceptor, spanFromContext sdk.SpanFromContext, spanAttributes map[string]string) grpc.UnaryClientInterceptor {
+func WrapUnaryClientInterceptor(delegateInterceptor grpc.UnaryClientInterceptor, spanFromContext sdk.SpanFromContext,
+	spanAttributes map[string]string) grpc.UnaryClientInterceptor {
 	defaultAttributes := map[string]string{
 		"rpc.system": "grpc",
 	}

--- a/sdk/instrumentation/google.golang.org/grpc/client.go
+++ b/sdk/instrumentation/google.golang.org/grpc/client.go
@@ -13,9 +13,12 @@ import (
 
 // WrapUnaryClientInterceptor returns an interceptor that records the request and response message's body
 // and serialize it as JSON.
-func WrapUnaryClientInterceptor(delegateInterceptor grpc.UnaryClientInterceptor, spanFromContext sdk.SpanFromContext) grpc.UnaryClientInterceptor {
+func WrapUnaryClientInterceptor(delegateInterceptor grpc.UnaryClientInterceptor, spanFromContext sdk.SpanFromContext, spanAttributes map[string]string) grpc.UnaryClientInterceptor {
 	defaultAttributes := map[string]string{
 		"rpc.system": "grpc",
+	}
+	for k, v := range spanAttributes {
+		defaultAttributes[k] = v
 	}
 	if containerID, err := container.GetID(); err == nil {
 		defaultAttributes["container_id"] = containerID

--- a/sdk/instrumentation/google.golang.org/grpc/server.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server.go
@@ -29,9 +29,13 @@ func WrapUnaryServerInterceptor(
 	delegateInterceptor grpc.UnaryServerInterceptor,
 	spanFromContext sdk.SpanFromContext,
 	options *Options,
+	spanAttributes map[string]string,
 ) grpc.UnaryServerInterceptor {
 	defaultAttributes := map[string]string{
 		"rpc.system": "grpc",
+	}
+	for k, v := range spanAttributes {
+		defaultAttributes[k] = v
 	}
 	if containerID, err := container.GetID(); err == nil {
 		defaultAttributes["container_id"] = containerID


### PR DESCRIPTION
## Description
RegisterService returns the TracerProvider created when a service is registered so that it can be passed onto config options of consumers who use otel instrumentation eg. otelgrpc. Also the grpc instrumentation can also take in a map of attributes to be added to every span.

### Testing
Manual tests

### Checklist:
- [ ✅ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

