### PR TITLE
feat: provide api to pass additional span attributes to http instrumentation

### DIFF
--- a/examples/http-server/main.go
+++ b/examples/http-server/main.go
@@ -20,6 +20,9 @@ import (
 func main() {
 	cfg := config.Load()
 	cfg.ServiceName = config.String("http-server")
+	// Switch to OTLP since default reporting endpoint is ZIPKIN
+	cfg.Reporting.TraceReporterType = config.TraceReporterType_OTLP
+	cfg.Reporting.Endpoint = config.String("localhost:4317")
 
 	flusher := hypertrace.Init(cfg)
 	defer flusher()

--- a/instrumentation/hypertrace/net/hyperhttp/handler.go
+++ b/instrumentation/hypertrace/net/hyperhttp/handler.go
@@ -16,7 +16,7 @@ func NewHandler(base http.Handler, operation string, opts ...Option) http.Handle
 	}
 
 	return otelhttp.NewHandler(
-		sdkhttp.WrapHandler(base, opentelemetry.SpanFromContext, o.toSDKOptions()),
+		sdkhttp.WrapHandler(base, opentelemetry.SpanFromContext, o.toSDKOptions(), map[string]string{}),
 		operation,
 	)
 }

--- a/instrumentation/hypertrace/net/hyperhttp/transport.go
+++ b/instrumentation/hypertrace/net/hyperhttp/transport.go
@@ -12,6 +12,6 @@ import (
 // starts a span and injects the span context into the outbound request headers.
 func NewTransport(base http.RoundTripper) http.RoundTripper {
 	return otelhttp.NewTransport(
-		sdkhttp.WrapTransport(base, opentelemetry.SpanFromContext),
+		sdkhttp.WrapTransport(base, opentelemetry.SpanFromContext, map[string]string{}),
 	)
 }

--- a/instrumentation/opencensus/net/hyperhttp/handler.go
+++ b/instrumentation/opencensus/net/hyperhttp/handler.go
@@ -10,5 +10,5 @@ import (
 // WrapHandler returns a new http.Handler that should be passed to
 // the *ochttp.Handler
 func WrapHandler(delegate http.Handler, options *sdkhttp.Options) http.Handler {
-	return sdkhttp.WrapHandler(delegate, opencensus.SpanFromContext, options)
+	return sdkhttp.WrapHandler(delegate, opencensus.SpanFromContext, options, map[string]string{})
 }

--- a/instrumentation/opencensus/net/hyperhttp/transport.go
+++ b/instrumentation/opencensus/net/hyperhttp/transport.go
@@ -10,5 +10,5 @@ import (
 // WrapTransport returns a new http.RoundTripper that should be passed to
 // the OpenCensus *ochttp.Transport
 func WrapTransport(delegate http.RoundTripper) http.RoundTripper {
-	return sdkhttp.WrapTransport(delegate, opencensus.SpanFromContext)
+	return sdkhttp.WrapTransport(delegate, opencensus.SpanFromContext, map[string]string{})
 }

--- a/instrumentation/opentelemetry/github.com/gin-gonic/hypergin/gin.go
+++ b/instrumentation/opentelemetry/github.com/gin-gonic/hypergin/gin.go
@@ -91,7 +91,7 @@ func Middleware(options *sdkhttp.Options) gin.HandlerFunc {
 			wrappedHandler.c.Request = wrappedHandler.c.Request.WithContext(ctx)
 		}
 		return otelhttp.NewHandler(
-			sdkhttp.WrapHandler(delegate, opentelemetry.SpanFromContext, options),
+			sdkhttp.WrapHandler(delegate, opentelemetry.SpanFromContext, options, map[string]string{}),
 			"",
 			otelhttp.WithSpanNameFormatter(spanNameFormatter),
 		)

--- a/instrumentation/opentelemetry/github.com/gorilla/hypermux/mux.go
+++ b/instrumentation/opentelemetry/github.com/gorilla/hypermux/mux.go
@@ -32,7 +32,7 @@ func spanNameFormatter(operation string, r *http.Request) (spanName string) {
 func NewMiddleware(options *sdkhttp.Options) mux.MiddlewareFunc {
 	return func(delegate http.Handler) http.Handler {
 		return otelhttp.NewHandler(
-			sdkhttp.WrapHandler(delegate, opentelemetry.SpanFromContext, options),
+			sdkhttp.WrapHandler(delegate, opentelemetry.SpanFromContext, options, map[string]string{}),
 			"",
 			otelhttp.WithSpanNameFormatter(spanNameFormatter),
 		)

--- a/instrumentation/opentelemetry/net/hyperhttp/handler.go
+++ b/instrumentation/opentelemetry/net/hyperhttp/handler.go
@@ -10,5 +10,5 @@ import (
 // WrapHandler returns a new round tripper instrumented that relies on the
 // needs to be used with OTel instrumentation.
 func WrapHandler(delegate http.Handler, options *sdkhttp.Options) http.Handler {
-	return sdkhttp.WrapHandler(delegate, opentelemetry.SpanFromContext, options)
+	return sdkhttp.WrapHandler(delegate, opentelemetry.SpanFromContext, options, map[string]string{})
 }

--- a/instrumentation/opentelemetry/net/hyperhttp/transport.go
+++ b/instrumentation/opentelemetry/net/hyperhttp/transport.go
@@ -11,5 +11,5 @@ import (
 // and returns an instrumented RoundTripper that has to be used as base for the
 // OTel's RoundTripper.
 func WrapTransport(delegate http.RoundTripper) http.RoundTripper {
-	return sdkhttp.WrapTransport(delegate, opentelemetry.SpanFromContext)
+	return sdkhttp.WrapTransport(delegate, opentelemetry.SpanFromContext, map[string]string{})
 }

--- a/sdk/instrumentation/net/http/handler.go
+++ b/sdk/instrumentation/net/http/handler.go
@@ -28,8 +28,11 @@ type Options struct {
 
 // WrapHandler wraps an uninstrumented handler (e.g. a handleFunc) and returns a new one
 // that should be used as base to an instrumented handler
-func WrapHandler(delegate http.Handler, spanFromContext sdk.SpanFromContext, options *Options) http.Handler {
+func WrapHandler(delegate http.Handler, spanFromContext sdk.SpanFromContext, options *Options, spanAttributes map[string]string) http.Handler {
 	defaultAttributes := make(map[string]string)
+	for k, v := range spanAttributes {
+		defaultAttributes[k] = v
+	}
 	if containerID, err := container.GetID(); err == nil {
 		defaultAttributes["container_id"] = containerID
 	}

--- a/sdk/instrumentation/net/http/transport.go
+++ b/sdk/instrumentation/net/http/transport.go
@@ -86,8 +86,11 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // WrapTransport returns a new http.RoundTripper that should be wrapped
 // by an instrumented http.RoundTripper
-func WrapTransport(delegate http.RoundTripper, spanFromContextRetriever sdk.SpanFromContext) http.RoundTripper {
+func WrapTransport(delegate http.RoundTripper, spanFromContextRetriever sdk.SpanFromContext, spanAttributes map[string]string) http.RoundTripper {
 	defaultAttributes := make(map[string]string)
+	for k, v := range spanAttributes {
+		defaultAttributes[k] = v
+	}
 	if containerID, err := container.GetID(); err == nil {
 		defaultAttributes["container_id"] = containerID
 	}


### PR DESCRIPTION
## Description
Modify the API to pass a map of strings as attributes to be added to the spans created during net/http instrumentation.

### Testing
Unit tests. Will run the example and verify the additional span attributes appear in the spans.

### Checklist:
- [✅  ] My changes generate no new warnings
- [ ✅ ] I have added tests that prove my fix is effective or that my feature works

