### PR TITLE
feat: Add filter interface Evaluate()

### DIFF
--- a/examples/http-server/main.go
+++ b/examples/http-server/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -65,7 +66,7 @@ func fooHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(fmt.Sprintf("{\"message\": \"Hello %s\"}", p.Name)))
 }
 
-func outgoingCallHandler(w, http.ResponseWriter, r *http.Request) {
+func outgoingCallHandler(w http.ResponseWriter, r *http.Request) {
 	client := http.Client{
 		Transport: hyperhttp.NewTransport(
 			http.DefaultTransport,

--- a/sdk/filter/filter.go
+++ b/sdk/filter/filter.go
@@ -4,9 +4,12 @@ import "github.com/hypertrace/goagent/sdk"
 
 // Filter evaluates whether request should be blocked, `true` blocks the request and `false` continues it.
 type Filter interface {
-	// EvaluateURLAndHeaders can be used to evaluate both URL and Headers
+	// EvaluateURLAndHeaders can be used to evaluate both URL and headers
 	EvaluateURLAndHeaders(span sdk.Span, url string, headers map[string][]string) bool
 
 	// EvaluateBody can be used to evaluate the body content
 	EvaluateBody(span sdk.Span, body []byte, headers map[string][]string) bool
+
+	// Evaluate can be used to evaluate URL, headers and body content in one call
+	Evaluate(span sdk.Span, url string, body []byte, headers map[string][]string) bool
 }

--- a/sdk/filter/multifilter.go
+++ b/sdk/filter/multifilter.go
@@ -33,3 +33,13 @@ func (m *MultiFilter) EvaluateBody(span sdk.Span, body []byte, headers map[strin
 	}
 	return false
 }
+
+// Evaluate runs body evaluators for each filter until one returns true
+func (m *MultiFilter) Evaluate(span sdk.Span, url string, body []byte, headers map[string][]string) bool {
+	for _, f := range (*m).filters {
+		if f.Evaluate(span, url, body, headers) {
+			return true
+		}
+	}
+	return false
+}

--- a/sdk/filter/multifilter_test.go
+++ b/sdk/filter/multifilter_test.go
@@ -12,12 +12,14 @@ func TestMultiFilterEmpty(t *testing.T) {
 	f := NewMultiFilter()
 	assert.False(t, f.EvaluateURLAndHeaders(nil, "", nil))
 	assert.False(t, f.EvaluateBody(nil, nil, nil))
+	assert.False(t, f.Evaluate(nil, "", nil, nil))
 }
 
 func TestMultiFilterStopsAfterTrue(t *testing.T) {
 	tCases := map[string]struct {
 		expectedURLAndHeadersFilterResult bool
 		expectedBodyFilterResult          bool
+		expectedFilterResult              bool
 		multiFilter                       *MultiFilter
 	}{
 		"URL and Headers multi filter": {
@@ -63,12 +65,34 @@ func TestMultiFilterStopsAfterTrue(t *testing.T) {
 				},
 			),
 		},
+		"Evaluate multi filter": {
+			expectedFilterResult: true,
+			multiFilter: NewMultiFilter(
+				mock.Filter{
+					Evaluator: func(span sdk.Span, url string, body []byte, headers map[string][]string) bool {
+						return false
+					},
+				},
+				mock.Filter{
+					Evaluator: func(span sdk.Span, url string, body []byte, headers map[string][]string) bool {
+						return true
+					},
+				},
+				mock.Filter{
+					Evaluator: func(span sdk.Span, url string, body []byte, headers map[string][]string) bool {
+						assert.Fail(t, "should not be called")
+						return false
+					},
+				},
+			),
+		},
 	}
 
 	for name, tCase := range tCases {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tCase.expectedURLAndHeadersFilterResult, tCase.multiFilter.EvaluateURLAndHeaders(nil, "", nil))
 			assert.Equal(t, tCase.expectedBodyFilterResult, tCase.multiFilter.EvaluateBody(nil, nil, nil))
+			assert.Equal(t, tCase.expectedFilterResult, tCase.multiFilter.Evaluate(nil, "", nil, nil))
 		})
 	}
 }

--- a/sdk/filter/noop.go
+++ b/sdk/filter/noop.go
@@ -16,3 +16,8 @@ func (NoopFilter) EvaluateURLAndHeaders(span sdk.Span, url string, headers map[s
 func (NoopFilter) EvaluateBody(span sdk.Span, body []byte, headers map[string][]string) bool {
 	return false
 }
+
+// Evaluate that always returns false
+func (NoopFilter) Evaluate(span sdk.Span, url string, body []byte, headers map[string][]string) bool {
+	return false
+}

--- a/sdk/filter/noop_test.go
+++ b/sdk/filter/noop_test.go
@@ -10,4 +10,5 @@ func TestNoopFilter(t *testing.T) {
 	f := NoopFilter{}
 	assert.False(t, f.EvaluateURLAndHeaders(nil, "", nil))
 	assert.False(t, f.EvaluateBody(nil, nil, nil))
+	assert.False(t, f.Evaluate(nil, "", nil, nil))
 }

--- a/sdk/internal/mock/filter.go
+++ b/sdk/internal/mock/filter.go
@@ -5,6 +5,7 @@ import "github.com/hypertrace/goagent/sdk"
 type Filter struct {
 	URLAndHeadersEvaluator func(span sdk.Span, url string, headers map[string][]string) bool
 	BodyEvaluator          func(span sdk.Span, body []byte, headers map[string][]string) bool
+	Evaluator              func(span sdk.Span, url string, body []byte, headers map[string][]string) bool
 }
 
 func (f Filter) EvaluateURLAndHeaders(span sdk.Span, url string, headers map[string][]string) bool {
@@ -13,4 +14,8 @@ func (f Filter) EvaluateURLAndHeaders(span sdk.Span, url string, headers map[str
 
 func (f Filter) EvaluateBody(span sdk.Span, body []byte, headers map[string][]string) bool {
 	return f.BodyEvaluator != nil && f.BodyEvaluator(span, body, headers)
+}
+
+func (f Filter) Evaluate(span sdk.Span, url string, body []byte, headers map[string][]string) bool {
+	return f.Evaluator != nil && f.Evaluator(span, url, body, headers)
 }


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

This PR adds a new Filter interface that is a combination of EvaluateURLAndHeaders and EvaluateBody. The motivation is performance if we do not need two calls. 

### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

Added/updated the unit tests. 
