### PR TITLE
feat: multipart/form-data data capture support

### DIFF
--- a/sdk/instrumentation/bodyattribute/bodyattribute.go
+++ b/sdk/instrumentation/bodyattribute/bodyattribute.go
@@ -1,6 +1,7 @@
 package bodyattribute // import "github.com/hypertrace/goagent/sdk/instrumentation/bodyattribute"
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	"github.com/hypertrace/goagent/sdk"
@@ -23,4 +24,23 @@ func SetTruncatedBodyAttribute(attrName string, body []byte, bodyMaxSize int, sp
 	truncatedBody := body[:bodyMaxSize]
 	span.SetAttribute(fmt.Sprintf("%s.truncated", attrName), true)
 	span.SetAttribute(attrName, string(truncatedBody))
+}
+
+// SetTruncatedEncodedBodyAttribute is like SetTruncatedBodyAttribute above but also base64 encodes the
+// body. This is usually due to non utf8 bytes in the body eg. for multipart/form-data content type.
+// The body attribute name has a ".base64" suffix.
+func SetTruncatedEncodedBodyAttribute(attrName string, body []byte, bodyMaxSize int, span sdk.Span) {
+	bodyLen := len(body)
+	if bodyLen == 0 {
+		return
+	}
+
+	if bodyLen <= bodyMaxSize {
+		span.SetAttribute(attrName+".base64", base64.RawStdEncoding.EncodeToString(body))
+		return
+	}
+
+	truncatedBody := body[:bodyMaxSize]
+	span.SetAttribute(fmt.Sprintf("%s.truncated", attrName), true)
+	span.SetAttribute(attrName+".base64", base64.RawStdEncoding.EncodeToString(truncatedBody))
 }

--- a/sdk/instrumentation/bodyattribute/bodyattribute_test.go
+++ b/sdk/instrumentation/bodyattribute/bodyattribute_test.go
@@ -44,3 +44,10 @@ func TestSetTruncatedEncodedBodyAttribute(t *testing.T) {
 	assert.True(t, (s.ReadAttribute("http.request.body.truncated")).(bool))
 	assert.Zero(t, s.RemainingAttributes())
 }
+
+func TestSetTruncatedEncodedBodyAttributeEmptyBody(t *testing.T) {
+	s := mock.NewSpan()
+	SetTruncatedEncodedBodyAttribute("http.request.body", []byte{}, 2, s)
+	assert.Nil(t, s.ReadAttribute("http.request.body.base64"))
+	assert.Zero(t, s.RemainingAttributes())
+}

--- a/sdk/instrumentation/bodyattribute/bodyattribute_test.go
+++ b/sdk/instrumentation/bodyattribute/bodyattribute_test.go
@@ -1,6 +1,7 @@
 package bodyattribute
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/hypertrace/goagent/sdk/internal/mock"
@@ -26,5 +27,20 @@ func TestBodyTruncationEmptyBody(t *testing.T) {
 	s := mock.NewSpan()
 	SetTruncatedBodyAttribute("body_attr", []byte{}, 7, s)
 	assert.Nil(t, s.ReadAttribute("body_attr"))
+	assert.Zero(t, s.RemainingAttributes())
+}
+
+func TestSetTruncatedEncodedBodyAttributeNoTruncation(t *testing.T) {
+	s := mock.NewSpan()
+	SetTruncatedEncodedBodyAttribute("http.request.body", []byte("text"), 7, s)
+	assert.Equal(t, base64.RawStdEncoding.EncodeToString([]byte("text")), s.ReadAttribute("http.request.body.base64"))
+	assert.Zero(t, s.RemainingAttributes())
+}
+
+func TestSetTruncatedEncodedBodyAttribute(t *testing.T) {
+	s := mock.NewSpan()
+	SetTruncatedEncodedBodyAttribute("http.request.body", []byte("text"), 2, s)
+	assert.Equal(t, base64.RawStdEncoding.EncodeToString([]byte("te")), s.ReadAttribute("http.request.body.base64"))
+	assert.True(t, (s.ReadAttribute("http.request.body.truncated")).(bool))
 	assert.Zero(t, s.RemainingAttributes())
 }

--- a/sdk/instrumentation/net/http/body.go
+++ b/sdk/instrumentation/net/http/body.go
@@ -9,7 +9,14 @@ import (
 
 // setTruncatedBodyAttribute truncates the body and sets the HTTP body as a span attribute.
 // When body is being truncated, we also add a second attribute suffixed by `.truncated` to
-// make it clear to the user, body has been modified.
-func setTruncatedBodyAttribute(_type string, body []byte, bodyMaxSize int, span sdk.Span) {
-	bodyattribute.SetTruncatedBodyAttribute(fmt.Sprintf("http.%s.body", _type), body, bodyMaxSize, span)
+// make it clear to the user, body has been modified. Also if base64Encode == true, we base64
+// encode the body and append the suffix ".base64" to the attribute name. We base64 encode in
+// in case there are non utf8 bytes in the body eg. for binary files in multipart/form-data
+// content-type.
+func setTruncatedBodyAttribute(_type string, body []byte, bodyMaxSize int, span sdk.Span, base64Encode bool) {
+	if base64Encode {
+		bodyattribute.SetTruncatedEncodedBodyAttribute(fmt.Sprintf("http.%s.body", _type), body, bodyMaxSize, span)
+	} else {
+		bodyattribute.SetTruncatedBodyAttribute(fmt.Sprintf("http.%s.body", _type), body, bodyMaxSize, span)
+	}
 }

--- a/sdk/instrumentation/net/http/body_test.go
+++ b/sdk/instrumentation/net/http/body_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/hypertrace/goagent/sdk/internal/mock"
@@ -9,7 +10,7 @@ import (
 
 func TestBodyTruncationSuccess(t *testing.T) {
 	s := mock.NewSpan()
-	setTruncatedBodyAttribute("request", []byte("text"), 2, s)
+	setTruncatedBodyAttribute("request", []byte("text"), 2, s, false)
 	assert.Equal(t, "te", s.ReadAttribute("http.request.body"))
 	assert.True(t, (s.ReadAttribute("http.request.body.truncated")).(bool))
 	assert.Zero(t, s.RemainingAttributes())
@@ -17,7 +18,15 @@ func TestBodyTruncationSuccess(t *testing.T) {
 
 func TestBodyTruncationIsSkipped(t *testing.T) {
 	s := mock.NewSpan()
-	setTruncatedBodyAttribute("request", []byte("text"), 7, s)
+	setTruncatedBodyAttribute("request", []byte("text"), 7, s, false)
 	assert.Equal(t, "text", s.ReadAttribute("http.request.body"))
+	assert.Zero(t, s.RemainingAttributes())
+}
+
+func TestSetTruncatedEncodedBodyAttribute(t *testing.T) {
+	s := mock.NewSpan()
+	setTruncatedBodyAttribute("request", []byte("text"), 2, s, true)
+	assert.Equal(t, base64.RawStdEncoding.EncodeToString([]byte("te")), s.ReadAttribute("http.request.body.base64"))
+	assert.True(t, (s.ReadAttribute("http.request.body.truncated")).(bool))
 	assert.Zero(t, s.RemainingAttributes())
 }

--- a/sdk/instrumentation/net/http/contenttype.go
+++ b/sdk/instrumentation/net/http/contenttype.go
@@ -5,11 +5,13 @@ import (
 	"strings"
 )
 
+const contentTypeHeaderKey string = "Content-Type"
+
 // ShouldRecordBodyOfContentType checks if the body is meant
 // to be recorded based on the content-type and the fact that body is
 // not streamed.
 func ShouldRecordBodyOfContentType(h HeaderAccessor) bool {
-	var contentTypeValues = h.Lookup("Content-Type") // "Content-Type" is the canonical key
+	var contentTypeValues = h.Lookup(contentTypeHeaderKey) // "Content-Type" is the canonical key
 	cfg := internalconfig.GetConfig().GetDataCapture()
 	if cfg == nil || cfg.GetAllowedContentTypes() == nil {
 		return false
@@ -39,6 +41,18 @@ func ShouldRecordBodyOfContentType(h HeaderAccessor) bool {
 			if strings.Contains(strings.ToLower(contentTypeValue), strings.ToLower(contentTypeAllowed.Value)) {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// HasMultiPartFormDataContentTypeHeader returns true if the Content-Type header is
+// multipart/form-data. false otherwise.
+func HasMultiPartFormDataContentTypeHeader(h HeaderAccessor) bool {
+	var contentTypeValues = h.Lookup(contentTypeHeaderKey)
+	for _, contentTypeValue := range contentTypeValues {
+		if strings.Contains(strings.ToLower(contentTypeValue), "multipart/form-data") {
+			return true
 		}
 	}
 	return false

--- a/sdk/instrumentation/net/http/contenttype_test.go
+++ b/sdk/instrumentation/net/http/contenttype_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRecordingDecissionReturnsFalseOnNoContentType(t *testing.T) {
+func TestRecordingDecisionReturnsFalseOnNoContentType(t *testing.T) {
 	assert.Equal(t, false, ShouldRecordBodyOfContentType(headerMapAccessor{http.Header{"A": []string{"B"}}}))
 }
 
-func TestRecordingDecissionSuccessOnHeaderSet(t *testing.T) {
+func TestRecordingDecisionSuccessOnHeaderSet(t *testing.T) {
 	internalconfig.ResetConfig()
 	tCases := []struct {
 		contentType  string
@@ -36,7 +36,7 @@ func TestRecordingDecissionSuccessOnHeaderSet(t *testing.T) {
 	}
 }
 
-func TestRecordingDecissionSuccessOnHeaderAdd(t *testing.T) {
+func TestRecordingDecisionSuccessOnHeaderAdd(t *testing.T) {
 	internalconfig.ResetConfig()
 	tCases := []struct {
 		contentTypes []string
@@ -83,4 +83,22 @@ func TestXMLRecordingDecisionSuccessOnHeaderAdd(t *testing.T) {
 		assert.Equal(t, tCase.shouldRecord, ShouldRecordBodyOfContentType(headerMapAccessor{h}))
 	}
 	internalconfig.ResetConfig()
+}
+
+func TestHasMultiPartFormDataContentTypeHeader(t *testing.T) {
+	tCases := []struct {
+		contentType         string
+		isMultiPartFormData bool
+	}{
+		{"text/plain", false},
+		{"application/json", false},
+		{"multipart/form-data", true},
+		{"multipart/mixed", false},
+	}
+
+	for _, tCase := range tCases {
+		h := http.Header{}
+		h.Set("Content-Type", tCase.contentType)
+		assert.Equal(t, tCase.isMultiPartFormData, HasMultiPartFormDataContentTypeHeader(headerMapAccessor{h}))
+	}
 }

--- a/sdk/instrumentation/net/http/handler.go
+++ b/sdk/instrumentation/net/http/handler.go
@@ -2,6 +2,7 @@ package http // import "github.com/hypertrace/goagent/sdk/instrumentation/net/ht
 
 import (
 	"bytes"
+	"encoding/base64"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -87,16 +88,24 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		defer r.Body.Close()
 
+		isMultipartFormDataBody := HasMultiPartFormDataContentTypeHeader(headerMapAccessor{r.Header})
+
 		// Only records the body if it is not empty and the content type
 		// header is not streamable
 		if len(body) > 0 {
 			setTruncatedBodyAttribute("request", body, int(h.dataCaptureConfig.BodyMaxSizeBytes.Value), span,
-				HasMultiPartFormDataContentTypeHeader(headerMapAccessor{r.Header}))
+				isMultipartFormDataBody)
 		}
 
 		processingBody := body
 		if int(h.dataCaptureConfig.BodyMaxProcessingSizeBytes.Value) < len(body) {
 			processingBody = body[:h.dataCaptureConfig.BodyMaxProcessingSizeBytes.Value]
+		}
+		// if body is multipart/form-data, base64 encode it before passing it on to the filter
+		if isMultipartFormDataBody {
+			origProcessingBody := processingBody
+			processingBody = make([]byte, base64.RawStdEncoding.EncodedLen(len(origProcessingBody)))
+			base64.RawStdEncoding.Encode(processingBody, origProcessingBody)
 		}
 
 		// run body filters

--- a/sdk/instrumentation/net/http/handler.go
+++ b/sdk/instrumentation/net/http/handler.go
@@ -90,7 +90,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Only records the body if it is not empty and the content type
 		// header is not streamable
 		if len(body) > 0 {
-			setTruncatedBodyAttribute("request", body, int(h.dataCaptureConfig.BodyMaxSizeBytes.Value), span)
+			setTruncatedBodyAttribute("request", body, int(h.dataCaptureConfig.BodyMaxSizeBytes.Value), span,
+				HasMultiPartFormDataContentTypeHeader(headerMapAccessor{r.Header}))
 		}
 
 		processingBody := body
@@ -116,7 +117,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if h.dataCaptureConfig.HttpBody.Response.Value &&
 			len(wi.body) > 0 &&
 			ShouldRecordBodyOfContentType(headerMapAccessor{wi.Header()}) {
-			setTruncatedBodyAttribute("response", wi.body, int(h.dataCaptureConfig.BodyMaxSizeBytes.Value), span)
+			setTruncatedBodyAttribute("response", wi.body, int(h.dataCaptureConfig.BodyMaxSizeBytes.Value), span,
+				HasMultiPartFormDataContentTypeHeader(headerMapAccessor{wi.Header()}))
 		}
 
 		if h.dataCaptureConfig.HttpHeaders.Response.Value {

--- a/sdk/instrumentation/net/http/handler_test.go
+++ b/sdk/instrumentation/net/http/handler_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -179,6 +180,8 @@ func TestServerRecordsRequestAndResponseBodyAccordingly(t *testing.T) {
 		responseBody                   string
 		responseContentType            string
 		shouldHaveRecordedResponseBody bool
+		shouldBase64EncodeRequestBody  bool
+		shouldBase64EncodeResponseBody bool
 	}{
 		"no content type headers and empty body": {
 			captureHTTPBodyConfig:          true,
@@ -217,6 +220,61 @@ func TestServerRecordsRequestAndResponseBodyAccordingly(t *testing.T) {
 			shouldHaveRecordedRequestBody:  false,
 			shouldHaveRecordedResponseBody: false,
 		},
+		"request has multipart/form-data content type and body with config enabled": {
+			captureHTTPBodyConfig:          true,
+			requestBody:                    "test_request_body",
+			responseBody:                   "test_response_body",
+			requestContentType:             "multipart/form-data",
+			responseContentType:            "application/json; charset=utf-8",
+			shouldHaveRecordedRequestBody:  true,
+			shouldHaveRecordedResponseBody: true,
+			shouldBase64EncodeRequestBody:  true,
+			shouldBase64EncodeResponseBody: false,
+		},
+		"response has multipart/form-data content type and body with config enabled": {
+			captureHTTPBodyConfig:          true,
+			requestBody:                    "test_request_body",
+			responseBody:                   "test_response_body",
+			requestContentType:             "application/json; charset=utf-8",
+			responseContentType:            "multipart/form-data",
+			shouldHaveRecordedRequestBody:  true,
+			shouldHaveRecordedResponseBody: true,
+			shouldBase64EncodeRequestBody:  false,
+			shouldBase64EncodeResponseBody: true,
+		},
+		"both request and response has multipart/form-data content type and body with config enabled": {
+			captureHTTPBodyConfig:          true,
+			requestBody:                    "test_request_body",
+			responseBody:                   "test_response_body",
+			requestContentType:             "multipart/form-data",
+			responseContentType:            "multipart/form-data",
+			shouldHaveRecordedRequestBody:  true,
+			shouldHaveRecordedResponseBody: true,
+			shouldBase64EncodeRequestBody:  true,
+			shouldBase64EncodeResponseBody: true,
+		},
+		"both request and response has multipart/form-data content type and body capture disabled": {
+			captureHTTPBodyConfig:          false,
+			requestBody:                    "test_request_body",
+			responseBody:                   "test_response_body",
+			requestContentType:             "multipart/form-data",
+			responseContentType:            "multipart/form-data",
+			shouldHaveRecordedRequestBody:  false,
+			shouldHaveRecordedResponseBody: false,
+			shouldBase64EncodeRequestBody:  true,
+			shouldBase64EncodeResponseBody: true,
+		},
+		"both request and response has multipart/form-data content type and multipart form-data body capture disabled": {
+			captureHTTPBodyConfig:          true,
+			requestBody:                    "test_request_body",
+			responseBody:                   "test_response_body",
+			requestContentType:             "multipart/form-data",
+			responseContentType:            "multipart/form-data",
+			shouldHaveRecordedRequestBody:  false,
+			shouldHaveRecordedResponseBody: false,
+			shouldBase64EncodeRequestBody:  false,
+			shouldBase64EncodeResponseBody: false,
+		},
 	}
 
 	for name, tCase := range tCases {
@@ -233,6 +291,12 @@ func TestServerRecordsRequestAndResponseBodyAccordingly(t *testing.T) {
 				Request:  config.Bool(tCase.captureHTTPBodyConfig),
 				Response: config.Bool(tCase.captureHTTPBodyConfig),
 			}
+			defaultAllowedContentTypes := internalconfig.GetConfig().DataCapture.AllowedContentTypes
+			// add multipart/form-data to the allowed content types.
+			if tCase.shouldBase64EncodeRequestBody || tCase.shouldBase64EncodeResponseBody {
+				internalconfig.GetConfig().DataCapture.AllowedContentTypes = append(internalconfig.GetConfig().DataCapture.AllowedContentTypes,
+					config.String("multipart/form-data"))
+			}
 			ih := &mockHandler{baseHandler: wh}
 
 			r, _ := http.NewRequest("GET", "http://traceable.ai/foo", strings.NewReader(tCase.requestBody))
@@ -245,16 +309,34 @@ func TestServerRecordsRequestAndResponseBodyAccordingly(t *testing.T) {
 			span := ih.spans[0]
 
 			if tCase.shouldHaveRecordedRequestBody {
-				assert.Equal(t, tCase.requestBody, span.ReadAttribute("http.request.body").(string))
+				if tCase.shouldBase64EncodeRequestBody {
+					assert.Equal(t, base64.RawStdEncoding.EncodeToString([]byte(tCase.requestBody)),
+						span.ReadAttribute("http.request.body.base64").(string))
+					assert.Nil(t, span.ReadAttribute("http.request.body"))
+				} else {
+					assert.Equal(t, tCase.requestBody, span.ReadAttribute("http.request.body").(string))
+					assert.Nil(t, span.ReadAttribute("http.request.body.base64"))
+				}
 			} else {
 				assert.Nil(t, span.ReadAttribute("http.request.body"))
+				assert.Nil(t, span.ReadAttribute("http.request.body.base64"))
 			}
 
 			if tCase.shouldHaveRecordedResponseBody {
-				assert.Equal(t, tCase.responseBody, span.ReadAttribute("http.response.body").(string))
+				if tCase.shouldBase64EncodeResponseBody {
+					assert.Equal(t, base64.RawStdEncoding.EncodeToString([]byte(tCase.responseBody)),
+						span.ReadAttribute("http.response.body.base64").(string))
+					assert.Nil(t, span.ReadAttribute("http.response.body"))
+				} else {
+					assert.Equal(t, tCase.responseBody, span.ReadAttribute("http.response.body").(string))
+					assert.Nil(t, span.ReadAttribute("http.response.body.base64"))
+				}
 			} else {
 				assert.Nil(t, span.ReadAttribute("http.response.body"))
+				assert.Nil(t, span.ReadAttribute("http.response.body.base64"))
 			}
+			// reset allowed content types config
+			internalconfig.GetConfig().DataCapture.AllowedContentTypes = defaultAllowedContentTypes
 		})
 	}
 }

--- a/sdk/instrumentation/net/http/transport.go
+++ b/sdk/instrumentation/net/http/transport.go
@@ -50,7 +50,8 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		defer req.Body.Close()
 
 		if len(body) > 0 {
-			setTruncatedBodyAttribute("request", body, int(rt.dataCaptureConfig.BodyMaxSizeBytes.Value), span)
+			setTruncatedBodyAttribute("request", body, int(rt.dataCaptureConfig.BodyMaxSizeBytes.Value), span,
+				HasMultiPartFormDataContentTypeHeader(headerMapAccessor{req.Header}))
 		}
 
 		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
@@ -70,7 +71,8 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		defer res.Body.Close()
 
 		if len(body) > 0 {
-			setTruncatedBodyAttribute("response", body, int(rt.dataCaptureConfig.BodyMaxSizeBytes.Value), span)
+			setTruncatedBodyAttribute("response", body, int(rt.dataCaptureConfig.BodyMaxSizeBytes.Value), span,
+				HasMultiPartFormDataContentTypeHeader(headerMapAccessor{res.Header}))
 		}
 
 		res.Body = ioutil.NopCloser(bytes.NewBuffer(body))


### PR DESCRIPTION
## Description
Support capturing multipart/form-data request and response body. Note that we are base64 encoding these types of bodies since they may contain non utf8 bytes which would break the exporters.

### Testing
Added unit tests and verified locally using an example

### Checklist:
- [ ✅ ] My changes generate no new warnings
- [✅  ] I have added tests that prove my fix is effective or that my feature works
- [✅  ] Any dependent changes have been merged and published in downstream modules

