### PR TITLE
Version should include -dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -2,4 +2,4 @@
 
 package version
 
-const Version = "0.10.0"
+const Version = "0.10.1-dev"


### PR DESCRIPTION
## Description
The version string should not have been updated to exclude the `-dev` portion of the string