### PR TITLE
Add "service.instance.id" to every span

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.4
 	github.com/ngrok/sqlmw v0.0.0-20200129213757-d5c93a81bec6
 	github.com/openzipkin/zipkin-go v0.4.0
+	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/stretchr/testify v1.8.1
-	github.com/satori/go.uuid v1.2.0
 	go.opencensus.io v0.23.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.35.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.35.0
@@ -29,7 +29,6 @@ require (
 	google.golang.org/grpc v1.49.0
 	google.golang.org/protobuf v1.28.1
 )
-
 
 require (
 	cloud.google.com/go v0.81.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.4
 	github.com/ngrok/sqlmw v0.0.0-20200129213757-d5c93a81bec6
 	github.com/openzipkin/zipkin-go v0.4.0
-	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/stretchr/testify v1.8.1
 	go.opencensus.io v0.23.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.35.0
@@ -29,6 +28,8 @@ require (
 	google.golang.org/grpc v1.49.0
 	google.golang.org/protobuf v1.28.1
 )
+
+require github.com/google/uuid v1.1.2
 
 require (
 	cloud.google.com/go v0.81.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/ngrok/sqlmw v0.0.0-20200129213757-d5c93a81bec6
 	github.com/openzipkin/zipkin-go v0.4.0
 	github.com/stretchr/testify v1.8.1
+	github.com/satori/go.uuid v1.2.0
 	go.opencensus.io v0.23.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.35.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.35.0
@@ -28,6 +29,7 @@ require (
 	google.golang.org/grpc v1.49.0
 	google.golang.org/protobuf v1.28.1
 )
+
 
 require (
 	cloud.google.com/go v0.81.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,7 @@ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -267,10 +268,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
-github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
-github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
+github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/go.sum
+++ b/go.sum
@@ -267,6 +267,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
+github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/instrumentation/opentelemetry/internal/identifier/identifier.go
+++ b/instrumentation/opentelemetry/internal/identifier/identifier.go
@@ -5,7 +5,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-var ServiceInstanceIDAttr = attribute.StringValue(uuid.NewV4().String())
+var instanceId, _ = uuid.NewV4()
+var ServiceInstanceIDAttr = attribute.StringValue(instanceId.String())
 
 const ServiceInstanceIDKey = "service.instance.id"
 

--- a/instrumentation/opentelemetry/internal/identifier/identifier.go
+++ b/instrumentation/opentelemetry/internal/identifier/identifier.go
@@ -1,12 +1,11 @@
 package identifier
 
 import (
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 )
 
-var instanceId, _ = uuid.NewV4()
-var ServiceInstanceIDAttr = attribute.StringValue(instanceId.String())
+var ServiceInstanceIDAttr = attribute.StringValue(uuid.New().String())
 
 const ServiceInstanceIDKey = "service.instance.id"
 

--- a/instrumentation/opentelemetry/internal/identifier/identifier.go
+++ b/instrumentation/opentelemetry/internal/identifier/identifier.go
@@ -1,0 +1,12 @@
+package identifier
+
+import (
+	uuid "github.com/satori/go.uuid"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+var ServiceInstanceIDAttr = attribute.StringValue(uuid.NewV4().String())
+
+const ServiceInstanceIDKey = "service.instance.id"
+
+var ServiceInstanceKeyValue = attribute.KeyValue{Key: ServiceInstanceIDKey, Value: ServiceInstanceIDAttr}

--- a/instrumentation/opentelemetry/span.go
+++ b/instrumentation/opentelemetry/span.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hypertrace/goagent/instrumentation/opentelemetry/internal/identifier"
 	"github.com/hypertrace/goagent/sdk"
 	"github.com/hypertrace/goagent/version"
 	"go.opentelemetry.io/otel"
@@ -111,7 +112,6 @@ func startSpan(provider getTracerProvider) sdk.StartSpan {
 
 		if opts != nil {
 			startOpts = append(startOpts, trace.WithSpanKind(mapSpanKind(opts.Kind)))
-
 			if opts.Timestamp.IsZero() {
 				startOpts = append(startOpts, trace.WithTimestamp(time.Now()))
 			} else {
@@ -122,6 +122,9 @@ func startSpan(provider getTracerProvider) sdk.StartSpan {
 		ctx, span := provider().
 			Tracer(TracerDomain, trace.WithInstrumentationVersion(version.Version)).
 			Start(ctx, name, startOpts...)
+
+		span.SetAttributes(identifier.ServiceInstanceKeyValue)
+
 		return ctx, &Span{span}, func() { span.End() }
 	}
 }

--- a/instrumentation/opentelemetry/span.go
+++ b/instrumentation/opentelemetry/span.go
@@ -118,12 +118,11 @@ func startSpan(provider getTracerProvider) sdk.StartSpan {
 				startOpts = append(startOpts, trace.WithTimestamp(opts.Timestamp))
 			}
 		}
+		startOpts = append(startOpts, trace.WithAttributes(identifier.ServiceInstanceKeyValue))
 
 		ctx, span := provider().
 			Tracer(TracerDomain, trace.WithInstrumentationVersion(version.Version)).
 			Start(ctx, name, startOpts...)
-
-		span.SetAttributes(identifier.ServiceInstanceKeyValue)
 
 		return ctx, &Span{span}, func() { span.End() }
 	}

--- a/instrumentation/opentelemetry/span_test.go
+++ b/instrumentation/opentelemetry/span_test.go
@@ -3,6 +3,7 @@ package opentelemetry
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -46,6 +47,16 @@ func TestSetAttributeSuccess(t *testing.T) {
 	s.SetAttribute("test_key_3", float64(1.2))
 	s.SetAttribute("test_key_4", "abc")
 	s.SetAttribute("test_key_4", errors.New("xyz"))
+}
+
+func TestSpanHasSameServiceInstanceId(t *testing.T) {
+	_, original, _ := StartSpan(context.Background(), "test_span", &sdk.SpanOptions{})
+	firstId := original.GetAttributes().GetValue("service.instance.id")
+	for i := 0; i < 300; i++ {
+		_, anotherSpan, _ := StartSpan(context.Background(), fmt.Sprintf("%s%d", "test_span", i), &sdk.SpanOptions{})
+		nextId := anotherSpan.GetAttributes().GetValue("service.instance.id")
+		assert.Equal(t, firstId, nextId)
+	}
 }
 
 func TestGenerateAttribute(t *testing.T) {


### PR DESCRIPTION
## Description

This adds a `service.instance.id` to every span.  

I tried adding this as a processor; however that didn't seem to work with our `InitWithSpanProcessorWrapper` I also tried adding it as a starting attribute using `trace.WithAttributes` however; those are filtered out during sampling.

Instead we just add it to each span during startSpan. If we'd prefer a different approach happy to revisit.(this seems like the most minimally invasive approach i think)

From docs about this attribute: 
> [3]: MUST be unique for each instance of the same service.namespace,service.name pair (in other words service.namespace,service.name,service.instance.id triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122 for more recommendations).

Specifically of note - I think we are okay with this being ephemeral for our specific use case.  (A restarting service will have different id) 