### PR TITLE
fix: disable metrics if using zipkin traces endpoint but empty metrics endpoint

### DIFF
--- a/instrumentation/opentelemetry/init.go
+++ b/instrumentation/opentelemetry/init.go
@@ -431,6 +431,7 @@ func initializeMetrics(cfg *config.AgentConfig) func() {
 func shouldDisableMetrics(cfg *config.AgentConfig) bool {
 	// Disable metrics if the tracing exporter is not OTLP(grpc) and the metrics endpoint is not explicitly set.
 	// This is because we use the traces OTLP endpoint for metrics if the metrics endpoint is not set.
+	// By default the traces endpoint is zipkin which does not have support for metrics.
 	if cfg.GetReporting() != nil && cfg.GetReporting().GetTraceReporterType() != config.TraceReporterType_OTLP &&
 		len(cfg.GetReporting().GetMetricEndpoint().GetValue()) == 0 {
 		return true

--- a/instrumentation/opentelemetry/init_test.go
+++ b/instrumentation/opentelemetry/init_test.go
@@ -395,3 +395,22 @@ func TestInitWithSpanProcessorWrapper(t *testing.T) {
 	assert.Equal(t, 3, wrapper.onStartCount)
 	assert.Equal(t, 3, wrapper.onEndCount)
 }
+
+func TestShouldDisableMetrics(t *testing.T) {
+	// Using default values: since zipkin is the default traces exporter turn off metrics
+	cfg := config.Load()
+	assert.True(t, shouldDisableMetrics(cfg))
+
+	// For OTLP reporting endpoint, turn it on
+	cfg.Reporting.TraceReporterType = config.TraceReporterType_OTLP
+	assert.False(t, shouldDisableMetrics(cfg))
+
+	cfg = config.Load()
+	cfg.Telemetry.MetricsEnabled = config.Bool(false)
+	assert.True(t, shouldDisableMetrics(cfg))
+
+	// Set a metrics endpoint
+	cfg = config.Load()
+	cfg.Reporting.MetricEndpoint = config.String("localhost:4317")
+	assert.False(t, shouldDisableMetrics(cfg))
+}


### PR DESCRIPTION
## Description
This is because we use the traces OTLP endpoint for metrics if the metrics endpoint is not set. By default the trace endpoint is zipkin which does not have support for metrics.

### Testing
Added unit tests and tested locally.

### Checklist:
- [ ✅ ] My changes generate no new warnings
- [✅  ] I have added tests that prove my fix is effective or that my feature works
- [ ✅ ] Any dependent changes have been merged and published in downstream modules

