### PR TITLE
fix: map HTTP response status code to equivalent GRPC Status code

### DIFF
--- a/sdk/instrumentation/google.golang.org/grpc/server.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server.go
@@ -11,7 +11,6 @@ import (
 	internalconfig "github.com/hypertrace/goagent/sdk/internal/config"
 	"github.com/hypertrace/goagent/sdk/internal/container"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/stats"
@@ -106,7 +105,7 @@ func wrapHandler(
 				}
 				filterResult := filter.EvaluateBody(span, processingBody, md)
 				if filterResult.Block {
-					return nil, status.Error(codes.Code(filterResult.ResponseStatusCode), StatusText(int(filterResult.ResponseStatusCode)))
+					return nil, status.Error(StatusCode(int(filterResult.ResponseStatusCode)), StatusText(int(filterResult.ResponseStatusCode)))
 				}
 			}
 		}
@@ -118,7 +117,7 @@ func wrapHandler(
 				// TODO: decide what should be passed as URL in GRPC
 				filterResult := filter.EvaluateURLAndHeaders(span, "", md)
 				if filterResult.Block {
-					return nil, status.Error(codes.Code(filterResult.ResponseStatusCode), StatusText(int(filterResult.ResponseStatusCode)))
+					return nil, status.Error(StatusCode(int(filterResult.ResponseStatusCode)), StatusText(int(filterResult.ResponseStatusCode)))
 				}
 			}
 		}

--- a/sdk/instrumentation/google.golang.org/grpc/status.go
+++ b/sdk/instrumentation/google.golang.org/grpc/status.go
@@ -1,5 +1,9 @@
 package grpc
 
+import (
+	"google.golang.org/grpc/codes"
+)
+
 func StatusText(code int) string {
 	switch code {
 	case 400:
@@ -62,5 +66,42 @@ func StatusText(code int) string {
 		return "Unavailable For Legal Reasons"
 	default:
 		return "Request Error"
+	}
+}
+
+// StatusCode does a best effort mapping from HTTP Request Status code to GRPC Code.
+func StatusCode(code int) codes.Code {
+	switch code {
+	case 400:
+		return codes.OutOfRange
+	case 401:
+		return codes.Unauthenticated
+	case 403:
+		return codes.PermissionDenied
+	case 404:
+		return codes.NotFound
+	case 407:
+		// "Proxy Authentication Required"
+		return codes.Unauthenticated
+	case 408:
+		// Request Timeout
+		return codes.DeadlineExceeded
+	case 412:
+		// "Precondition Failed"
+		return codes.FailedPrecondition
+	case 413:
+		// "Request Entity Too Large"
+		return codes.ResourceExhausted
+	case 414:
+		// "Request URI Too Long"
+		return codes.ResourceExhausted
+	case 429:
+		// "Too Many Requests"
+		return codes.ResourceExhausted
+	case 431:
+		// "Request Header Fields Too Large"
+		return codes.ResourceExhausted
+	default:
+		return codes.Unknown
 	}
 }

--- a/sdk/instrumentation/google.golang.org/grpc/status.go
+++ b/sdk/instrumentation/google.golang.org/grpc/status.go
@@ -72,8 +72,6 @@ func StatusText(code int) string {
 // StatusCode does a best effort mapping from HTTP Request Status code to GRPC Code.
 func StatusCode(code int) codes.Code {
 	switch code {
-	case 400:
-		return codes.OutOfRange
 	case 401:
 		return codes.Unauthenticated
 	case 403:
@@ -89,17 +87,10 @@ func StatusCode(code int) codes.Code {
 	case 412:
 		// "Precondition Failed"
 		return codes.FailedPrecondition
-	case 413:
-		// "Request Entity Too Large"
-		return codes.ResourceExhausted
-	case 414:
-		// "Request URI Too Long"
-		return codes.ResourceExhausted
-	case 429:
-		// "Too Many Requests"
-		return codes.ResourceExhausted
-	case 431:
-		// "Request Header Fields Too Large"
+	case 413, // "Request Entity Too Large"
+		414, // "Request URI Too Long"
+		429, // "Too Many Requests"
+		431: // "Request Header Fields Too Large"
 		return codes.ResourceExhausted
 	default:
 		return codes.Unknown

--- a/sdk/instrumentation/google.golang.org/grpc/status_test.go
+++ b/sdk/instrumentation/google.golang.org/grpc/status_test.go
@@ -1,0 +1,23 @@
+package grpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+)
+
+func TestStatusCode(t *testing.T) {
+	assert.Equal(t, codes.Unauthenticated, StatusCode(401))
+	assert.Equal(t, codes.PermissionDenied, StatusCode(403))
+	assert.Equal(t, codes.NotFound, StatusCode(404))
+	assert.Equal(t, codes.Unauthenticated, StatusCode(407))
+	assert.Equal(t, codes.DeadlineExceeded, StatusCode(408))
+	assert.Equal(t, codes.FailedPrecondition, StatusCode(412))
+	assert.Equal(t, codes.ResourceExhausted, StatusCode(413))
+	assert.Equal(t, codes.ResourceExhausted, StatusCode(414))
+	assert.Equal(t, codes.ResourceExhausted, StatusCode(429))
+	assert.Equal(t, codes.ResourceExhausted, StatusCode(431))
+	assert.Equal(t, codes.Unknown, StatusCode(400))
+	assert.Equal(t, codes.Unknown, StatusCode(500))
+}


### PR DESCRIPTION
## Description
Need to map the HTTP status code returned by the filter logic to GRPC status code for GRPC instrumentation.

### Testing
Unit tests.

### Checklist:
- [ ✅ ] My changes generate no new warnings
- [ ✅ ] I have added tests that prove my fix is effective or that my feature works
- [✅  ] Any dependent changes have been merged and published in downstream modules

