### PR TITLE
 adding generic attributes interface 

### DIFF
--- a/instrumentation/opentelemetry/span.go
+++ b/instrumentation/opentelemetry/span.go
@@ -32,9 +32,10 @@ func (l *AttributeList) GetValue(key string) interface{} {
 }
 
 func (l *AttributeList) GetAll() []sdk.Attribute {
-	attributes := make([]sdk.Attribute, len(l.attrs))
-	for _, attr := range l.attrs {
-		attributes = append(attributes, sdk.Attribute{Key: string(attr.Key), Value: attr.Value.AsInterface()})
+	size := len(l.attrs)
+	attributes := make([]sdk.Attribute, size)
+	for i := 0; i < size; i++ {
+		attributes[i] = sdk.Attribute{Key: string(l.attrs[i].Key), Value: l.attrs[i].Value.AsInterface()}
 	}
 	return attributes
 }

--- a/instrumentation/opentelemetry/span.go
+++ b/instrumentation/opentelemetry/span.go
@@ -31,6 +31,14 @@ func (l *AttributeList) GetValue(key string) interface{} {
 	return nil
 }
 
+func (l *AttributeList) GetAll() []sdk.Attribute {
+	attributes := make([]sdk.Attribute, len(l.attrs))
+	for _, attr := range l.attrs {
+		attributes = append(attributes, sdk.Attribute{Key: string(attr.Key), Value: attr.Value.AsInterface()})
+	}
+	return attributes
+}
+
 var _ sdk.Span = (*Span)(nil)
 
 type Span struct {

--- a/instrumentation/opentelemetry/span_test.go
+++ b/instrumentation/opentelemetry/span_test.go
@@ -109,3 +109,23 @@ func TestGetAttributes(t *testing.T) {
 	assert.Equal(t, "string_value", attrs.GetValue("string_key"))
 	assert.Equal(t, nil, attrs.GetValue("non_existent"))
 }
+
+func TestGetAllAttributes(t *testing.T) {
+	sampler := sdktrace.AlwaysSample()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sampler),
+	)
+	otel.SetTracerProvider(tp)
+	_, s, _ := StartSpan(context.Background(), "test_span", &sdk.SpanOptions{})
+	s.SetAttribute("k1", "v1")
+	s.SetAttribute("k2", 200)
+	attrs := s.GetAttributes().GetAll()
+
+	for _, attr := range attrs {
+		if attr.Key == "k1" {
+			assert.Equal(t, "v1", fmt.Sprintf("%v", attr.Value))
+		} else if attr.Key == "k2" {
+			assert.Equal(t, "200", fmt.Sprintf("%v", attr.Value))
+		}
+	}
+}

--- a/instrumentation/opentelemetry/span_test.go
+++ b/instrumentation/opentelemetry/span_test.go
@@ -121,6 +121,7 @@ func TestGetAllAttributes(t *testing.T) {
 	s.SetAttribute("k2", 200)
 	attrs := s.GetAttributes().GetAll()
 
+	// service.instance.id is added implicitly in StartSpan so 3 attributes will be present.
 	assert.Equal(t, 3, len(attrs))
 	for _, attr := range attrs {
 		if attr.Key == "k1" {

--- a/instrumentation/opentelemetry/span_test.go
+++ b/instrumentation/opentelemetry/span_test.go
@@ -121,6 +121,7 @@ func TestGetAllAttributes(t *testing.T) {
 	s.SetAttribute("k2", 200)
 	attrs := s.GetAttributes().GetAll()
 
+	assert.Equal(t, 3, len(attrs))
 	for _, attr := range attrs {
 		if attr.Key == "k1" {
 			assert.Equal(t, "v1", fmt.Sprintf("%v", attr.Value))

--- a/sdk/internal/mock/span.go
+++ b/sdk/internal/mock/span.go
@@ -29,6 +29,14 @@ func (l *AttributeList) GetValue(key string) interface{} {
 	return l.attrs[key]
 }
 
+func (l *AttributeList) GetAll() []sdk.Attribute {
+	attributes := make([]sdk.Attribute, len(l.attrs))
+	for key, value := range l.attrs {
+		attributes = append(attributes, sdk.Attribute{Key: key, Value: value})
+	}
+	return attributes
+}
+
 var _ sdk.Span = &Span{}
 
 type Span struct {

--- a/sdk/internal/mock/span.go
+++ b/sdk/internal/mock/span.go
@@ -35,6 +35,7 @@ func (l *AttributeList) GetAll() []sdk.Attribute {
 	i := 0
 	for key, value := range l.attrs {
 		attributes[i] = sdk.Attribute{Key: key, Value: value}
+		i++
 	}
 	return attributes
 }

--- a/sdk/internal/mock/span.go
+++ b/sdk/internal/mock/span.go
@@ -30,9 +30,11 @@ func (l *AttributeList) GetValue(key string) interface{} {
 }
 
 func (l *AttributeList) GetAll() []sdk.Attribute {
+
 	attributes := make([]sdk.Attribute, len(l.attrs))
+	i := 0
 	for key, value := range l.attrs {
-		attributes = append(attributes, sdk.Attribute{Key: key, Value: value})
+		attributes[i] = sdk.Attribute{Key: key, Value: value}
 	}
 	return attributes
 }

--- a/sdk/span.go
+++ b/sdk/span.go
@@ -5,8 +5,14 @@ import (
 	"time"
 )
 
+type Attribute struct {
+	Key   string
+	Value interface{}
+}
+
 type AttributeList interface {
 	GetValue(key string) interface{}
+	GetAll() []Attribute
 }
 
 // Span is an interface that accepts attributes and can be


### PR DESCRIPTION
## Description
Adding a generic GetAll method for attributes so that all the attributes can be queried at once

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
