### PR TITLE
adding iterator interface and removing GetAll() method from attribute list

### DIFF
--- a/instrumentation/opentelemetry/span.go
+++ b/instrumentation/opentelemetry/span.go
@@ -60,6 +60,14 @@ func (l *AttributeList) GetIterator() sdk.Iterator {
 	}
 }
 
+func (l *AttributeList) IterateItems(yield func(attr sdk.Attribute) bool) {
+	for _, attr := range l.attrs {
+		if !yield(sdk.Attribute{Key: string(attr.Key), Value: attr.Value.AsInterface()}) {
+			return
+		}
+	}
+}
+
 var _ sdk.Span = (*Span)(nil)
 
 type Span struct {

--- a/instrumentation/opentelemetry/span.go
+++ b/instrumentation/opentelemetry/span.go
@@ -15,6 +15,27 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+var _ sdk.Iterator = (*Iterator)(nil)
+
+type Iterator struct {
+	size  int
+	curr  int
+	attrs []attribute.KeyValue
+}
+
+func (i *Iterator) HasNext() bool {
+	return i.curr < i.size
+}
+
+func (i *Iterator) Next() sdk.Attribute {
+	attr := sdk.Attribute{
+		Key:   string(i.attrs[i.curr].Key),
+		Value: i.attrs[i.curr].Value.AsInterface(),
+	}
+	i.curr++
+	return attr
+}
+
 var _ sdk.AttributeList = (*AttributeList)(nil)
 
 type AttributeList struct {
@@ -31,13 +52,12 @@ func (l *AttributeList) GetValue(key string) interface{} {
 	return nil
 }
 
-func (l *AttributeList) GetAll() []sdk.Attribute {
-	size := len(l.attrs)
-	attributes := make([]sdk.Attribute, size)
-	for i := 0; i < size; i++ {
-		attributes[i] = sdk.Attribute{Key: string(l.attrs[i].Key), Value: l.attrs[i].Value.AsInterface()}
+func (l *AttributeList) GetIterator() sdk.Iterator {
+	return &Iterator{
+		size:  len(l.attrs),
+		curr:  0,
+		attrs: l.attrs,
 	}
-	return attributes
 }
 
 var _ sdk.Span = (*Span)(nil)

--- a/instrumentation/opentelemetry/span.go
+++ b/instrumentation/opentelemetry/span.go
@@ -15,27 +15,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-var _ sdk.Iterator = (*Iterator)(nil)
-
-type Iterator struct {
-	size  int
-	curr  int
-	attrs []attribute.KeyValue
-}
-
-func (i *Iterator) HasNext() bool {
-	return i.curr < i.size
-}
-
-func (i *Iterator) Next() sdk.Attribute {
-	attr := sdk.Attribute{
-		Key:   string(i.attrs[i.curr].Key),
-		Value: i.attrs[i.curr].Value.AsInterface(),
-	}
-	i.curr++
-	return attr
-}
-
 var _ sdk.AttributeList = (*AttributeList)(nil)
 
 type AttributeList struct {
@@ -52,17 +31,9 @@ func (l *AttributeList) GetValue(key string) interface{} {
 	return nil
 }
 
-func (l *AttributeList) GetIterator() sdk.Iterator {
-	return &Iterator{
-		size:  len(l.attrs),
-		curr:  0,
-		attrs: l.attrs,
-	}
-}
-
-func (l *AttributeList) IterateItems(yield func(attr sdk.Attribute) bool) {
+func (l *AttributeList) Iterate(yield func(key string, value interface{}) bool) {
 	for _, attr := range l.attrs {
-		if !yield(sdk.Attribute{Key: string(attr.Key), Value: attr.Value.AsInterface()}) {
+		if !yield(string(attr.Key), attr.Value.AsInterface()) {
 			return
 		}
 	}

--- a/instrumentation/opentelemetry/span_test.go
+++ b/instrumentation/opentelemetry/span_test.go
@@ -110,32 +110,7 @@ func TestGetAttributes(t *testing.T) {
 	assert.Equal(t, nil, attrs.GetValue("non_existent"))
 }
 
-func TestGetIterator(t *testing.T) {
-	sampler := sdktrace.AlwaysSample()
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sampler),
-	)
-	otel.SetTracerProvider(tp)
-	_, s, _ := StartSpan(context.Background(), "test_span", &sdk.SpanOptions{})
-	s.SetAttribute("k1", "v1")
-	s.SetAttribute("k2", 200)
-	itr := s.GetAttributes().GetIterator()
-
-	numAttrs := 0
-	for itr.HasNext() {
-		numAttrs++
-		attr := itr.Next()
-		if attr.Key == "k1" {
-			assert.Equal(t, "v1", fmt.Sprintf("%v", attr.Value))
-		} else if attr.Key == "k2" {
-			assert.Equal(t, "200", fmt.Sprintf("%v", attr.Value))
-		}
-	}
-	// service.instance.id is added implicitly in StartSpan so 3 attributes will be present.
-	assert.Equal(t, 3, numAttrs)
-}
-
-func TestIterateItems(t *testing.T) {
+func TestIterate(t *testing.T) {
 	sampler := sdktrace.AlwaysSample()
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sampler),
@@ -146,11 +121,11 @@ func TestIterateItems(t *testing.T) {
 	s.SetAttribute("k2", 200)
 
 	numAttrs := 0
-	s.GetAttributes().IterateItems(func(attr sdk.Attribute) bool {
-		if attr.Key == "k1" {
-			assert.Equal(t, "v1", fmt.Sprintf("%v", attr.Value))
-		} else if attr.Key == "k2" {
-			assert.Equal(t, "200", fmt.Sprintf("%v", attr.Value))
+	s.GetAttributes().Iterate(func(key string, value interface{}) bool {
+		if key == "k1" {
+			assert.Equal(t, "v1", fmt.Sprintf("%v", value))
+		} else if key == "k2" {
+			assert.Equal(t, "200", fmt.Sprintf("%v", value))
 		}
 		numAttrs++
 		return true

--- a/instrumentation/opentelemetry/span_test.go
+++ b/instrumentation/opentelemetry/span_test.go
@@ -134,3 +134,27 @@ func TestGetIterator(t *testing.T) {
 	// service.instance.id is added implicitly in StartSpan so 3 attributes will be present.
 	assert.Equal(t, 3, numAttrs)
 }
+
+func TestIterateItems(t *testing.T) {
+	sampler := sdktrace.AlwaysSample()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sampler),
+	)
+	otel.SetTracerProvider(tp)
+	_, s, _ := StartSpan(context.Background(), "test_span", &sdk.SpanOptions{})
+	s.SetAttribute("k1", "v1")
+	s.SetAttribute("k2", 200)
+
+	numAttrs := 0
+	s.GetAttributes().IterateItems(func(attr sdk.Attribute) bool {
+		if attr.Key == "k1" {
+			assert.Equal(t, "v1", fmt.Sprintf("%v", attr.Value))
+		} else if attr.Key == "k2" {
+			assert.Equal(t, "200", fmt.Sprintf("%v", attr.Value))
+		}
+		numAttrs++
+		return true
+	})
+	// service.instance.id is added implicitly in StartSpan so 3 attributes will be present.
+	assert.Equal(t, 3, numAttrs)
+}

--- a/instrumentation/opentelemetry/span_test.go
+++ b/instrumentation/opentelemetry/span_test.go
@@ -110,7 +110,7 @@ func TestGetAttributes(t *testing.T) {
 	assert.Equal(t, nil, attrs.GetValue("non_existent"))
 }
 
-func TestGetAllAttributes(t *testing.T) {
+func TestGetIterator(t *testing.T) {
 	sampler := sdktrace.AlwaysSample()
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sampler),
@@ -119,15 +119,18 @@ func TestGetAllAttributes(t *testing.T) {
 	_, s, _ := StartSpan(context.Background(), "test_span", &sdk.SpanOptions{})
 	s.SetAttribute("k1", "v1")
 	s.SetAttribute("k2", 200)
-	attrs := s.GetAttributes().GetAll()
+	itr := s.GetAttributes().GetIterator()
 
-	// service.instance.id is added implicitly in StartSpan so 3 attributes will be present.
-	assert.Equal(t, 3, len(attrs))
-	for _, attr := range attrs {
+	numAttrs := 0
+	for itr.HasNext() {
+		numAttrs++
+		attr := itr.Next()
 		if attr.Key == "k1" {
 			assert.Equal(t, "v1", fmt.Sprintf("%v", attr.Value))
 		} else if attr.Key == "k2" {
 			assert.Equal(t, "200", fmt.Sprintf("%v", attr.Value))
 		}
 	}
+	// service.instance.id is added implicitly in StartSpan so 3 attributes will be present.
+	assert.Equal(t, 3, numAttrs)
 }

--- a/sdk/internal/mock/span.go
+++ b/sdk/internal/mock/span.go
@@ -19,29 +19,6 @@ type Status struct {
 	Message string
 }
 
-var _ sdk.Iterator = (*Iterator)(nil)
-
-type Iterator struct {
-	size   int
-	curr   int
-	keySet []string
-	attrs  map[string]interface{}
-}
-
-func (i *Iterator) HasNext() bool {
-	return i.curr < i.size
-}
-
-func (i *Iterator) Next() sdk.Attribute {
-	key := i.keySet[i.curr]
-	attr := sdk.Attribute{
-		Key:   key,
-		Value: i.attrs[key],
-	}
-	i.curr++
-	return attr
-}
-
 var _ sdk.AttributeList = (*AttributeList)(nil)
 
 type AttributeList struct {
@@ -52,20 +29,11 @@ func (l *AttributeList) GetValue(key string) interface{} {
 	return l.attrs[key]
 }
 
-func (l *AttributeList) GetIterator() sdk.Iterator {
-
-	keySet := make([]string, len(l.attrs))
-	i := 0
-	for k := range l.attrs {
-		keySet[i] = k
-		i++
-	}
-
-	return &Iterator{
-		size:   len(l.attrs),
-		curr:   0,
-		keySet: keySet,
-		attrs:  l.attrs,
+func (l *AttributeList) Iterate(yield func(key string, value interface{}) bool) {
+	for key, value := range l.attrs {
+		if !yield(key, value) {
+			return
+		}
 	}
 }
 

--- a/sdk/internal/mock/span.go
+++ b/sdk/internal/mock/span.go
@@ -19,6 +19,29 @@ type Status struct {
 	Message string
 }
 
+var _ sdk.Iterator = (*Iterator)(nil)
+
+type Iterator struct {
+	size   int
+	curr   int
+	keySet []string
+	attrs  map[string]interface{}
+}
+
+func (i *Iterator) HasNext() bool {
+	return i.curr < i.size
+}
+
+func (i *Iterator) Next() sdk.Attribute {
+	key := i.keySet[i.curr]
+	attr := sdk.Attribute{
+		Key:   key,
+		Value: i.attrs[key],
+	}
+	i.curr++
+	return attr
+}
+
 var _ sdk.AttributeList = (*AttributeList)(nil)
 
 type AttributeList struct {
@@ -29,15 +52,21 @@ func (l *AttributeList) GetValue(key string) interface{} {
 	return l.attrs[key]
 }
 
-func (l *AttributeList) GetAll() []sdk.Attribute {
+func (l *AttributeList) GetIterator() sdk.Iterator {
 
-	attributes := make([]sdk.Attribute, len(l.attrs))
+	keySet := make([]string, len(l.attrs))
 	i := 0
-	for key, value := range l.attrs {
-		attributes[i] = sdk.Attribute{Key: key, Value: value}
+	for k := range l.attrs {
+		keySet[i] = k
 		i++
 	}
-	return attributes
+
+	return &Iterator{
+		size:   len(l.attrs),
+		curr:   0,
+		keySet: keySet,
+		attrs:  l.attrs,
+	}
 }
 
 var _ sdk.Span = &Span{}

--- a/sdk/span.go
+++ b/sdk/span.go
@@ -18,6 +18,7 @@ type Iterator interface {
 type AttributeList interface {
 	GetValue(key string) interface{}
 	GetIterator() Iterator
+	IterateItems(yield func(attr Attribute) bool)
 }
 
 // Span is an interface that accepts attributes and can be

--- a/sdk/span.go
+++ b/sdk/span.go
@@ -5,20 +5,9 @@ import (
 	"time"
 )
 
-type Attribute struct {
-	Key   string
-	Value interface{}
-}
-
-type Iterator interface {
-	HasNext() bool
-	Next() Attribute
-}
-
 type AttributeList interface {
 	GetValue(key string) interface{}
-	GetIterator() Iterator
-	IterateItems(yield func(attr Attribute) bool)
+	Iterate(yield func(key string, value interface{}) bool)
 }
 
 // Span is an interface that accepts attributes and can be

--- a/sdk/span.go
+++ b/sdk/span.go
@@ -10,9 +10,14 @@ type Attribute struct {
 	Value interface{}
 }
 
+type Iterator interface {
+	HasNext() bool
+	Next() Attribute
+}
+
 type AttributeList interface {
 	GetValue(key string) interface{}
-	GetAll() []Attribute
+	GetIterator() Iterator
 }
 
 // Span is an interface that accepts attributes and can be

--- a/sdk/span.go
+++ b/sdk/span.go
@@ -7,6 +7,9 @@ import (
 
 type AttributeList interface {
 	GetValue(key string) interface{}
+
+	// Iterate loops through the attributes list and applies the yield function on each attribute.
+	// If the yield function returns false, we exit the loop.
 	Iterate(yield func(key string, value interface{}) bool)
 }
 


### PR DESCRIPTION
Adding an iterator interface on AttributeList so that the iterator can be queried without creating an additional slice. 
Continuation of this pr: https://github.com/hypertrace/goagent/pull/217
ref: https://github.com/hypertrace/goagent/pull/217/files#r1385540220

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

