### PR TITLE
ENG-37132: using already computed bodyLen

### DIFF
--- a/sdk/instrumentation/bodyattribute/bodyattribute.go
+++ b/sdk/instrumentation/bodyattribute/bodyattribute.go
@@ -29,7 +29,7 @@ func SetTruncatedBodyAttribute(attrName string, body []byte, bodyMaxSize int, sp
 // The body attribute name has a ".base64" suffix.
 func SetTruncatedEncodedBodyAttribute(attrName string, body []byte, bodyMaxSize int, span sdk.Span) {
 	bodyLen := len(body)
-	if len(body) == 0 {
+	if bodyLen == 0 {
 		return
 	}
 


### PR DESCRIPTION
## Description
Use already computed bodyLen variable

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules