### PR TITLE
feat: update filter interface to process only based on spans

### DIFF
--- a/sdk/filter/filter.go
+++ b/sdk/filter/filter.go
@@ -7,12 +7,6 @@ import (
 
 // Filter evaluates whether request should be blocked, `true` blocks the request and `false` continues it.
 type Filter interface {
-	// EvaluateURLAndHeaders can be used to evaluate both URL and headers
-	EvaluateURLAndHeaders(span sdk.Span, url string, headers map[string][]string) result.FilterResult
-
-	// EvaluateBody can be used to evaluate the body content
-	EvaluateBody(span sdk.Span, body []byte, headers map[string][]string) result.FilterResult
-
 	// Evaluate can be used to evaluate URL, headers and body content in one call
-	Evaluate(span sdk.Span, url string, body []byte, headers map[string][]string) result.FilterResult
+	Evaluate(span sdk.Span) result.FilterResult
 }

--- a/sdk/filter/multifilter.go
+++ b/sdk/filter/multifilter.go
@@ -17,32 +17,10 @@ func NewMultiFilter(filter ...Filter) *MultiFilter {
 	return &MultiFilter{filters: filter}
 }
 
-// EvaluateURLAndHeaders runs URL and headers evaluation for each filter until one returns true
-func (m *MultiFilter) EvaluateURLAndHeaders(span sdk.Span, url string, headers map[string][]string) result.FilterResult {
-	for _, f := range (*m).filters {
-		filterResult := f.EvaluateURLAndHeaders(span, url, headers)
-		if filterResult.Block {
-			return filterResult
-		}
-	}
-	return result.FilterResult{}
-}
-
-// EvaluateBody runs body evaluators for each filter until one returns true
-func (m *MultiFilter) EvaluateBody(span sdk.Span, body []byte, headers map[string][]string) result.FilterResult {
-	for _, f := range (*m).filters {
-		filterResult := f.EvaluateBody(span, body, headers)
-		if filterResult.Block {
-			return filterResult
-		}
-	}
-	return result.FilterResult{}
-}
-
 // Evaluate runs body evaluators for each filter until one returns true
-func (m *MultiFilter) Evaluate(span sdk.Span, url string, body []byte, headers map[string][]string) result.FilterResult {
+func (m *MultiFilter) Evaluate(span sdk.Span) result.FilterResult {
 	for _, f := range (*m).filters {
-		filterResult := f.Evaluate(span, url, body, headers)
+		filterResult := f.Evaluate(span)
 		if filterResult.Block {
 			return filterResult
 		}

--- a/sdk/filter/multifilter_test.go
+++ b/sdk/filter/multifilter_test.go
@@ -15,7 +15,7 @@ func TestMultiFilterEmpty(t *testing.T) {
 	assert.False(t, res.Block)
 	res = f.EvaluateBody(nil, nil, nil)
 	assert.False(t, res.Block)
-	res = f.Evaluate(nil, "", nil, nil)
+	res = f.Evaluate(nil)
 	assert.False(t, res.Block)
 }
 
@@ -99,7 +99,7 @@ func TestMultiFilterStopsAfterTrue(t *testing.T) {
 			assert.Equal(t, tCase.expectedURLAndHeadersFilterResult, res.Block)
 			res = tCase.multiFilter.EvaluateBody(nil, nil, nil)
 			assert.Equal(t, tCase.expectedBodyFilterResult, res.Block)
-			res = tCase.multiFilter.Evaluate(nil, "", nil, nil)
+			res = tCase.multiFilter.Evaluate(nil)
 			assert.Equal(t, tCase.expectedFilterResult, res.Block)
 		})
 	}

--- a/sdk/filter/multifilter_test.go
+++ b/sdk/filter/multifilter_test.go
@@ -11,11 +11,7 @@ import (
 
 func TestMultiFilterEmpty(t *testing.T) {
 	f := NewMultiFilter()
-	res := f.EvaluateURLAndHeaders(nil, "", nil)
-	assert.False(t, res.Block)
-	res = f.EvaluateBody(nil, nil, nil)
-	assert.False(t, res.Block)
-	res = f.Evaluate(nil)
+	res := f.Evaluate(nil)
 	assert.False(t, res.Block)
 }
 
@@ -26,65 +22,21 @@ func TestMultiFilterStopsAfterTrue(t *testing.T) {
 		expectedFilterResult              bool
 		multiFilter                       *MultiFilter
 	}{
-		"URL and Headers multi filter": {
-			expectedURLAndHeadersFilterResult: true,
-			expectedBodyFilterResult:          false,
-			expectedFilterResult:              false,
-			multiFilter: NewMultiFilter(
-				mock.Filter{
-					URLAndHeadersEvaluator: func(span sdk.Span, url string, headers map[string][]string) result.FilterResult {
-						return result.FilterResult{}
-					},
-				},
-				mock.Filter{
-					URLAndHeadersEvaluator: func(span sdk.Span, url string, headers map[string][]string) result.FilterResult {
-						return result.FilterResult{Block: true, ResponseStatusCode: 403}
-					},
-				},
-				mock.Filter{
-					URLAndHeadersEvaluator: func(span sdk.Span, url string, headers map[string][]string) result.FilterResult {
-						assert.Fail(t, "should not be called")
-						return result.FilterResult{}
-					},
-				},
-			),
-		},
-		"Body multi filter": {
-			expectedBodyFilterResult: true,
-			multiFilter: NewMultiFilter(
-				mock.Filter{
-					BodyEvaluator: func(span sdk.Span, body []byte, headers map[string][]string) result.FilterResult {
-						return result.FilterResult{}
-					},
-				},
-				mock.Filter{
-					BodyEvaluator: func(span sdk.Span, body []byte, headers map[string][]string) result.FilterResult {
-						return result.FilterResult{Block: true, ResponseStatusCode: 403}
-					},
-				},
-				mock.Filter{
-					BodyEvaluator: func(span sdk.Span, body []byte, headers map[string][]string) result.FilterResult {
-						assert.Fail(t, "should not be called")
-						return result.FilterResult{}
-					},
-				},
-			),
-		},
 		"Evaluate multi filter": {
 			expectedFilterResult: true,
 			multiFilter: NewMultiFilter(
 				mock.Filter{
-					Evaluator: func(span sdk.Span, url string, body []byte, headers map[string][]string) result.FilterResult {
+					Evaluator: func(span sdk.Span) result.FilterResult {
 						return result.FilterResult{}
 					},
 				},
 				mock.Filter{
-					Evaluator: func(span sdk.Span, url string, body []byte, headers map[string][]string) result.FilterResult {
+					Evaluator: func(span sdk.Span) result.FilterResult {
 						return result.FilterResult{Block: true, ResponseStatusCode: 403}
 					},
 				},
 				mock.Filter{
-					Evaluator: func(span sdk.Span, url string, body []byte, headers map[string][]string) result.FilterResult {
+					Evaluator: func(span sdk.Span) result.FilterResult {
 						assert.Fail(t, "should not be called")
 						return result.FilterResult{}
 					},
@@ -95,11 +47,7 @@ func TestMultiFilterStopsAfterTrue(t *testing.T) {
 
 	for name, tCase := range tCases {
 		t.Run(name, func(t *testing.T) {
-			res := tCase.multiFilter.EvaluateURLAndHeaders(nil, "", nil)
-			assert.Equal(t, tCase.expectedURLAndHeadersFilterResult, res.Block)
-			res = tCase.multiFilter.EvaluateBody(nil, nil, nil)
-			assert.Equal(t, tCase.expectedBodyFilterResult, res.Block)
-			res = tCase.multiFilter.Evaluate(nil)
+			res := tCase.multiFilter.Evaluate(nil)
 			assert.Equal(t, tCase.expectedFilterResult, res.Block)
 		})
 	}

--- a/sdk/filter/noop.go
+++ b/sdk/filter/noop.go
@@ -10,17 +10,7 @@ type NoopFilter struct{}
 
 var _ Filter = NoopFilter{}
 
-// EvaluateURLAndHeaders that always returns false
-func (NoopFilter) EvaluateURLAndHeaders(span sdk.Span, url string, headers map[string][]string) result.FilterResult {
-	return result.FilterResult{}
-}
-
-// EvaluateBody that always returns false
-func (NoopFilter) EvaluateBody(span sdk.Span, body []byte, headers map[string][]string) result.FilterResult {
-	return result.FilterResult{}
-}
-
 // Evaluate that always returns false
-func (NoopFilter) Evaluate(span sdk.Span, url string, body []byte, headers map[string][]string) result.FilterResult {
+func (NoopFilter) Evaluate(span sdk.Span) result.FilterResult {
 	return result.FilterResult{}
 }

--- a/sdk/filter/noop_test.go
+++ b/sdk/filter/noop_test.go
@@ -8,10 +8,6 @@ import (
 
 func TestNoopFilter(t *testing.T) {
 	f := NoopFilter{}
-	res := f.EvaluateURLAndHeaders(nil, "", nil)
-	assert.False(t, res.Block)
-	res = f.EvaluateBody(nil, nil, nil)
-	assert.False(t, res.Block)
-	res = f.Evaluate(nil)
+	res := f.Evaluate(nil)
 	assert.False(t, res.Block)
 }

--- a/sdk/filter/noop_test.go
+++ b/sdk/filter/noop_test.go
@@ -12,6 +12,6 @@ func TestNoopFilter(t *testing.T) {
 	assert.False(t, res.Block)
 	res = f.EvaluateBody(nil, nil, nil)
 	assert.False(t, res.Block)
-	res = f.Evaluate(nil, "", nil, nil)
+	res = f.Evaluate(nil)
 	assert.False(t, res.Block)
 }

--- a/sdk/instrumentation/google.golang.org/grpc/server_test.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server_test.go
@@ -116,7 +116,7 @@ func TestServerInterceptorFilter(t *testing.T) {
 			expectedFilterResult: true,
 			expectedStatusCode:   codes.PermissionDenied,
 			multiFilter: filter.NewMultiFilter(mock.Filter{
-				URLAndHeadersEvaluator: func(span sdk.Span, url string, headers map[string][]string) result.FilterResult {
+				Evaluator: func(span sdk.Span) result.FilterResult {
 					assert.Equal(t, []string{"test_value"}, headers["test_key"])
 					return result.FilterResult{Block: true, ResponseStatusCode: 403}
 				},

--- a/sdk/instrumentation/google.golang.org/grpc/server_test.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server_test.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	config "github.com/hypertrace/agent-config/gen/go/v1"
@@ -117,7 +118,7 @@ func TestServerInterceptorFilter(t *testing.T) {
 			expectedStatusCode:   codes.PermissionDenied,
 			multiFilter: filter.NewMultiFilter(mock.Filter{
 				Evaluator: func(span sdk.Span) result.FilterResult {
-					assert.Equal(t, []string{"test_value"}, headers["test_key"])
+					assert.Equal(t, "test_value", fmt.Sprintf("%s", span.GetAttributes().GetValue("rpc.request.metadata.test_key")))
 					return result.FilterResult{Block: true, ResponseStatusCode: 403}
 				},
 			}),
@@ -126,8 +127,8 @@ func TestServerInterceptorFilter(t *testing.T) {
 			expectedFilterResult: true,
 			expectedStatusCode:   codes.PermissionDenied,
 			multiFilter: filter.NewMultiFilter(mock.Filter{
-				BodyEvaluator: func(span sdk.Span, body []byte, headers map[string][]string) result.FilterResult {
-					assert.Equal(t, "{\"name\":\"Pupo\"}", string(body))
+				Evaluator: func(span sdk.Span) result.FilterResult {
+					assert.Equal(t, "{\"name\":\"Pupo\"}", span.GetAttributes().GetValue("rpc.request.body"))
 					return result.FilterResult{Block: true, ResponseStatusCode: 403}
 				},
 			}),
@@ -136,8 +137,8 @@ func TestServerInterceptorFilter(t *testing.T) {
 			expectedFilterResult: true,
 			expectedStatusCode:   codes.FailedPrecondition,
 			multiFilter: filter.NewMultiFilter(mock.Filter{
-				BodyEvaluator: func(span sdk.Span, body []byte, headers map[string][]string) result.FilterResult {
-					assert.Equal(t, "{\"name\":\"Pupo\"}", string(body))
+				Evaluator: func(span sdk.Span) result.FilterResult {
+					assert.Equal(t, "{\"name\":\"Pupo\"}", span.GetAttributes().GetValue("rpc.request.body"))
 					return result.FilterResult{Block: true, ResponseStatusCode: 412}
 				},
 			}),
@@ -198,7 +199,7 @@ func TestServerInterceptorFilterWithMaxProcessingBodyLen(t *testing.T) {
 			RpcBody: &config.Message{
 				Request: config.Bool(true),
 			},
-			BodyMaxProcessingSizeBytes: config.Int32(1),
+			BodyMaxSizeBytes: config.Int32(1),
 		},
 	}
 	cfg.LoadFromEnv()
@@ -210,8 +211,9 @@ func TestServerInterceptorFilterWithMaxProcessingBodyLen(t *testing.T) {
 	s := grpc.NewServer(
 		grpc.UnaryInterceptor(
 			WrapUnaryServerInterceptor(mockUnaryInterceptor, mock.SpanFromContext, &Options{Filter: mock.Filter{
-				BodyEvaluator: func(span sdk.Span, body []byte, headers map[string][]string) result.FilterResult {
-					assert.Equal(t, "{", string(body)) // body is truncated
+				Evaluator: func(span sdk.Span) result.FilterResult {
+					assert.Equal(t, true, span.GetAttributes().GetValue("rpc.request.body.truncated"))
+					assert.Equal(t, "{", span.GetAttributes().GetValue("rpc.request.body")) // body is truncated
 					return result.FilterResult{}
 				},
 			}}, nil),

--- a/sdk/internal/mock/filter.go
+++ b/sdk/internal/mock/filter.go
@@ -6,12 +6,12 @@ import (
 )
 
 type Filter struct {
-	Evaluator func(span sdk.Span, url string, body []byte, headers map[string][]string) result.FilterResult
+	Evaluator func(span sdk.Span) result.FilterResult
 }
 
 func (f Filter) Evaluate(span sdk.Span) result.FilterResult {
 	if f.Evaluator == nil {
 		return result.FilterResult{}
 	}
-	return f.Evaluator(span, url, body, headers)
+	return f.Evaluator(span)
 }

--- a/sdk/internal/mock/filter.go
+++ b/sdk/internal/mock/filter.go
@@ -6,26 +6,10 @@ import (
 )
 
 type Filter struct {
-	URLAndHeadersEvaluator func(span sdk.Span, url string, headers map[string][]string) result.FilterResult
-	BodyEvaluator          func(span sdk.Span, body []byte, headers map[string][]string) result.FilterResult
-	Evaluator              func(span sdk.Span, url string, body []byte, headers map[string][]string) result.FilterResult
+	Evaluator func(span sdk.Span, url string, body []byte, headers map[string][]string) result.FilterResult
 }
 
-func (f Filter) EvaluateURLAndHeaders(span sdk.Span, url string, headers map[string][]string) result.FilterResult {
-	if f.URLAndHeadersEvaluator == nil {
-		return result.FilterResult{}
-	}
-	return f.URLAndHeadersEvaluator(span, url, headers)
-}
-
-func (f Filter) EvaluateBody(span sdk.Span, body []byte, headers map[string][]string) result.FilterResult {
-	if f.BodyEvaluator == nil {
-		return result.FilterResult{}
-	}
-	return f.BodyEvaluator(span, body, headers)
-}
-
-func (f Filter) Evaluate(span sdk.Span, url string, body []byte, headers map[string][]string) result.FilterResult {
+func (f Filter) Evaluate(span sdk.Span) result.FilterResult {
 	if f.Evaluator == nil {
 		return result.FilterResult{}
 	}


### PR DESCRIPTION
## Description
Updating the filter interface to have only a single method, `Evaluate`. And when calling evaluate, all the relevant attributes/headers are expected to be present as part of the span

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

