### PR TITLE
feat: adding length method to attribute list and updating http.url attribute in net/http instrumentation

### DIFF
--- a/instrumentation/opentelemetry/span.go
+++ b/instrumentation/opentelemetry/span.go
@@ -39,6 +39,10 @@ func (l *AttributeList) Iterate(yield func(key string, value interface{}) bool) 
 	}
 }
 
+func (l *AttributeList) Len() int {
+	return len(l.attrs)
+}
+
 var _ sdk.Span = (*Span)(nil)
 
 type Span struct {

--- a/instrumentation/opentelemetry/span_test.go
+++ b/instrumentation/opentelemetry/span_test.go
@@ -133,3 +133,17 @@ func TestIterate(t *testing.T) {
 	// service.instance.id is added implicitly in StartSpan so 3 attributes will be present.
 	assert.Equal(t, 3, numAttrs)
 }
+
+func TestLen(t *testing.T) {
+	sampler := sdktrace.AlwaysSample()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sampler),
+	)
+	otel.SetTracerProvider(tp)
+	_, s, _ := StartSpan(context.Background(), "test_span", &sdk.SpanOptions{})
+	s.SetAttribute("k1", "v1")
+	s.SetAttribute("k2", 200)
+
+	// service.instance.id is added implicitly in StartSpan so 3 attributes will be present.
+	assert.Equal(t, 3, s.GetAttributes().Len())
+}

--- a/sdk/instrumentation/net/http/handler.go
+++ b/sdk/instrumentation/net/http/handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"strings"
 
 	config "github.com/hypertrace/agent-config/gen/go/v1"
 	"github.com/hypertrace/goagent/sdk"
@@ -65,7 +66,11 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	url := r.URL.String()
-	span.SetAttribute("http.url", url)
+	if strings.Contains(url, "://") {
+		span.SetAttribute("http.url", url)
+	} else {
+		span.SetAttribute("http.target", url)
+	}
 
 	host := r.Host
 	span.SetAttribute("http.request.header.host", host)

--- a/sdk/internal/mock/span.go
+++ b/sdk/internal/mock/span.go
@@ -37,6 +37,10 @@ func (l *AttributeList) Iterate(yield func(key string, value interface{}) bool) 
 	}
 }
 
+func (l *AttributeList) Len() int {
+	return len(l.attrs)
+}
+
 var _ sdk.Span = &Span{}
 
 type Span struct {

--- a/sdk/span.go
+++ b/sdk/span.go
@@ -11,6 +11,8 @@ type AttributeList interface {
 	// Iterate loops through the attributes list and applies the yield function on each attribute.
 	// If the yield function returns false, we exit the loop.
 	Iterate(yield func(key string, value interface{}) bool)
+
+	Len() int
 }
 
 // Span is an interface that accepts attributes and can be


### PR DESCRIPTION
## Description
1. adding a length method to attribute list
2. Updating the http.url attribute in net/http instrumentation in case if its not the complete url

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
