### PR TITLE
feat: updating filter result to add decorations

### DIFF
--- a/sdk/filter/result/filter_result.go
+++ b/sdk/filter/result/filter_result.go
@@ -1,8 +1,8 @@
 package result
 
 type KeyValueString struct {
-	key   string
-	value string
+	Key   string
+	Value string
 }
 
 type Decorations struct {
@@ -13,5 +13,5 @@ type FilterResult struct {
 	Block              bool
 	ResponseStatusCode int32
 	ResponseMessage    string
-	Decorations        Decorations
+	Decorations        *Decorations
 }

--- a/sdk/filter/result/filter_result.go
+++ b/sdk/filter/result/filter_result.go
@@ -1,7 +1,17 @@
 package result
 
+type KeyValueString struct {
+	key   string
+	value string
+}
+
+type Decorations struct {
+	RequestHeaderInjections []KeyValueString
+}
+
 type FilterResult struct {
 	Block              bool
 	ResponseStatusCode int32
 	ResponseMessage    string
+	Decorations        Decorations
 }

--- a/sdk/instrumentation/google.golang.org/grpc/common_test.go
+++ b/sdk/instrumentation/google.golang.org/grpc/common_test.go
@@ -18,17 +18,22 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 )
 
-var _ helloworld.GreeterServer = server{}
+// type assertion
+var _ helloworld.GreeterServer = (*server)(nil)
 
 type server struct {
-	err          error
-	replyHeader  metadata.MD
-	replyTrailer metadata.MD
+	err           error
+	requestHeader metadata.MD
+	replyHeader   metadata.MD
+	replyTrailer  metadata.MD
 	*helloworld.UnimplementedGreeterServer
 }
 
-func (s server) SayHello(ctx context.Context, req *helloworld.HelloRequest) (*helloworld.HelloReply, error) {
+func (s *server) SayHello(ctx context.Context, req *helloworld.HelloRequest) (*helloworld.HelloReply, error) {
 	var reply *helloworld.HelloReply
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		s.requestHeader = md
+	}
 	if s.err == nil {
 		reply = &helloworld.HelloReply{Message: fmt.Sprintf("Hello %s", req.GetName())}
 	}

--- a/sdk/instrumentation/google.golang.org/grpc/server.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server.go
@@ -2,7 +2,6 @@ package grpc // import "github.com/hypertrace/goagent/sdk/instrumentation/google
 
 import (
 	"context"
-	"google.golang.org/grpc/metadata"
 	"net/http"
 	"strings"
 
@@ -13,6 +12,7 @@ import (
 	internalconfig "github.com/hypertrace/goagent/sdk/internal/config"
 	"github.com/hypertrace/goagent/sdk/internal/container"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"

--- a/sdk/instrumentation/google.golang.org/grpc/server_test.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server_test.go
@@ -294,6 +294,7 @@ func TestServerInterceptorFilterDecorations(t *testing.T) {
 	_, err = client.SayHello(ctx, &helloworld.HelloRequest{
 		Name: "Pupo",
 	})
+	assert.NoError(t, err)
 
 	md := mockServer.requestHeader
 	// assert original header
@@ -360,6 +361,7 @@ func TestServerInterceptorFilterEmptyDecorations(t *testing.T) {
 	_, err = client.SayHello(ctx, &helloworld.HelloRequest{
 		Name: "Pupo",
 	})
+	assert.NoError(t, err)
 
 	md := mockServer.requestHeader
 	// assert original header

--- a/sdk/instrumentation/google.golang.org/grpc/server_test.go
+++ b/sdk/instrumentation/google.golang.org/grpc/server_test.go
@@ -248,6 +248,128 @@ func TestServerInterceptorFilterWithMaxProcessingBodyLen(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestServerInterceptorFilterDecorations(t *testing.T) {
+	var spans []*mock.Span
+	mockInterceptor := makeMockUnaryServerInterceptor(&spans)
+	// wrap interceptor with filter
+	s := grpc.NewServer(
+		grpc.UnaryInterceptor(
+			WrapUnaryServerInterceptor(mockInterceptor, mock.SpanFromContext, &Options{Filter: mock.Filter{
+				Evaluator: func(span sdk.Span) result.FilterResult {
+					return result.FilterResult{Block: false, Decorations: &result.Decorations{
+						RequestHeaderInjections: []result.KeyValueString{
+							{
+								Key:   "injected-header",
+								Value: "injected-value",
+							},
+						},
+					}}
+				},
+			}}, nil),
+		),
+	)
+	defer s.Stop()
+
+	mockServer := &server{}
+	helloworld.RegisterGreeterServer(s, mockServer)
+
+	dialer := createDialer(s)
+
+	ctx := context.Background()
+	conn, err := grpc.DialContext(
+		ctx,
+		"bufnet",
+		grpc.WithContextDialer(dialer),
+		grpc.WithBlock(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("failed to dial bufnet: %v", err)
+	}
+	defer conn.Close()
+
+	client := helloworld.NewGreeterClient(conn)
+
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("test_key", "test_value"))
+	_, err = client.SayHello(ctx, &helloworld.HelloRequest{
+		Name: "Pupo",
+	})
+
+	md := mockServer.requestHeader
+	// assert original header
+	val, found := md["test_key"]
+	assert.True(t, found)
+	assert.Equal(t, "test_value", val[0])
+
+	// assert injected header
+	val, found = md["injected-header"]
+	assert.True(t, found)
+	assert.Equal(t, "injected-value", val[0])
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(spans))
+	span := spans[0]
+	spanAttributePresent := false
+	span.GetAttributes().Iterate(func(key string, value interface{}) bool {
+		if key == "rpc.request.metadata.injected-header" {
+			assert.Equal(t, "injected-value", value.(string))
+			spanAttributePresent = true
+			return false
+		}
+		return true
+	})
+	assert.True(t, spanAttributePresent)
+}
+
+func TestServerInterceptorFilterEmptyDecorations(t *testing.T) {
+	spans := []*mock.Span{}
+	mockInterceptor := makeMockUnaryServerInterceptor(&spans)
+	// wrap interceptor with filter
+	s := grpc.NewServer(
+		grpc.UnaryInterceptor(
+			WrapUnaryServerInterceptor(mockInterceptor, mock.SpanFromContext, &Options{Filter: mock.Filter{
+				Evaluator: func(span sdk.Span) result.FilterResult {
+					return result.FilterResult{Block: false, Decorations: &result.Decorations{}}
+				},
+			}}, nil),
+		),
+	)
+	defer s.Stop()
+
+	mockServer := &server{}
+	helloworld.RegisterGreeterServer(s, mockServer)
+
+	dialer := createDialer(s)
+
+	ctx := context.Background()
+	conn, err := grpc.DialContext(
+		ctx,
+		"bufnet",
+		grpc.WithContextDialer(dialer),
+		grpc.WithBlock(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("failed to dial bufnet: %v", err)
+	}
+	defer conn.Close()
+
+	client := helloworld.NewGreeterClient(conn)
+
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("test_key", "test_value"))
+	_, err = client.SayHello(ctx, &helloworld.HelloRequest{
+		Name: "Pupo",
+	})
+
+	md := mockServer.requestHeader
+	// assert original header
+	val, found := md["test_key"]
+	assert.True(t, found)
+	assert.Equal(t, "test_value", val[0])
+
+	assert.Equal(t, 1, len(spans))
+}
+
 func TestServerHandlerHelloWorldSuccess(t *testing.T) {
 	defer internalconfig.ResetConfig()
 

--- a/sdk/instrumentation/net/http/attributes_test.go
+++ b/sdk/instrumentation/net/http/attributes_test.go
@@ -12,7 +12,7 @@ func TestSetScalarAttributeSuccess(t *testing.T) {
 	h := http.Header{}
 	h.Set("key_1", "value_1")
 	span := mock.NewSpan()
-	SetAttributesFromHeaders("request", headerMapAccessor{h}, span)
+	SetAttributesFromHeaders("request", &headerMapAccessor{h}, span)
 	assert.Equal(t, "value_1", span.ReadAttribute("http.request.header.key_1").(string))
 
 	_ = span.ReadAttribute("container_id") // needed in containarized envs
@@ -25,7 +25,7 @@ func TestSetMultivalueAttributeSuccess(t *testing.T) {
 	h.Add("key_1", "value_2")
 
 	span := mock.NewSpan()
-	SetAttributesFromHeaders("response", headerMapAccessor{h}, span)
+	SetAttributesFromHeaders("response", &headerMapAccessor{h}, span)
 
 	assert.Equal(t, "value_1", span.ReadAttribute("http.response.header.key_1[0]").(string))
 	assert.Equal(t, "value_2", span.ReadAttribute("http.response.header.key_1[1]").(string))

--- a/sdk/instrumentation/net/http/contenttype_test.go
+++ b/sdk/instrumentation/net/http/contenttype_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRecordingDecisionReturnsFalseOnNoContentType(t *testing.T) {
-	assert.Equal(t, false, ShouldRecordBodyOfContentType(headerMapAccessor{http.Header{"A": []string{"B"}}}))
+	assert.Equal(t, false, ShouldRecordBodyOfContentType(&headerMapAccessor{http.Header{"A": []string{"B"}}}))
 }
 
 func TestRecordingDecisionSuccessOnHeaderSet(t *testing.T) {
@@ -32,7 +32,7 @@ func TestRecordingDecisionSuccessOnHeaderSet(t *testing.T) {
 	for _, tCase := range tCases {
 		h := http.Header{}
 		h.Set("Content-Type", tCase.contentType)
-		assert.Equal(t, tCase.shouldRecord, ShouldRecordBodyOfContentType(headerMapAccessor{h}))
+		assert.Equal(t, tCase.shouldRecord, ShouldRecordBodyOfContentType(&headerMapAccessor{h}))
 	}
 }
 
@@ -56,7 +56,7 @@ func TestRecordingDecisionSuccessOnHeaderAdd(t *testing.T) {
 		for _, header := range tCase.contentTypes {
 			h.Add("Content-Type", header)
 		}
-		assert.Equal(t, tCase.shouldRecord, ShouldRecordBodyOfContentType(headerMapAccessor{h}))
+		assert.Equal(t, tCase.shouldRecord, ShouldRecordBodyOfContentType(&headerMapAccessor{h}))
 	}
 }
 
@@ -80,7 +80,7 @@ func TestXMLRecordingDecisionSuccessOnHeaderAdd(t *testing.T) {
 		for _, header := range tCase.contentTypes {
 			h.Add("Content-Type", header)
 		}
-		assert.Equal(t, tCase.shouldRecord, ShouldRecordBodyOfContentType(headerMapAccessor{h}))
+		assert.Equal(t, tCase.shouldRecord, ShouldRecordBodyOfContentType(&headerMapAccessor{h}))
 	}
 	internalconfig.ResetConfig()
 }
@@ -99,6 +99,6 @@ func TestHasMultiPartFormDataContentTypeHeader(t *testing.T) {
 	for _, tCase := range tCases {
 		h := http.Header{}
 		h.Set("Content-Type", tCase.contentType)
-		assert.Equal(t, tCase.isMultiPartFormData, HasMultiPartFormDataContentTypeHeader(headerMapAccessor{h}))
+		assert.Equal(t, tCase.isMultiPartFormData, HasMultiPartFormDataContentTypeHeader(&headerMapAccessor{h}))
 	}
 }

--- a/sdk/instrumentation/net/http/headeraccessor.go
+++ b/sdk/instrumentation/net/http/headeraccessor.go
@@ -9,28 +9,34 @@ import "net/http"
 type HeaderAccessor interface {
 	Lookup(key string) []string
 	ForEachHeader(callback func(key string, values []string) error) error
+	AddHeader(key, values string)
 }
 
 type headerMapAccessor struct {
 	header http.Header
 }
 
-var _ HeaderAccessor = headerMapAccessor{}
+// type assertion
+var _ HeaderAccessor = (*headerMapAccessor)(nil)
 
 // NewHeaderMapAccessor returns a HeaderAccessor
 func NewHeaderMapAccessor(h http.Header) HeaderAccessor {
 	return &headerMapAccessor{h}
 }
 
-func (a headerMapAccessor) Lookup(key string) []string {
+func (a *headerMapAccessor) Lookup(key string) []string {
 	return a.header[http.CanonicalHeaderKey(key)]
 }
 
-func (a headerMapAccessor) ForEachHeader(callback func(key string, values []string) error) error {
+func (a *headerMapAccessor) ForEachHeader(callback func(key string, values []string) error) error {
 	for key, values := range a.header {
 		if err := callback(key, values); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (a *headerMapAccessor) AddHeader(key, value string) {
+	a.header.Set(key, value)
 }


### PR DESCRIPTION
## Description
Adding a Decoration field to FilterResult. The Decoration struct can have mutations defined on request or response objects which should be applied on a filter result match. Starting with request header injections, in which a list of headers can be specified to be injected on a filter evaluation match 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
